### PR TITLE
feat: SQL-first migrations + deep health checks (/healthz?deep=true) + migration runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with: { python-version: "3.11" }
+    - run: pip install --upgrade pip && pip install .[dev]
+    - run: ruff check .
+    - run: black --check .

--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ Next:
   - MI_GENAI_TIMEOUT_S=25
   - MI_RUN_SUMMARY_DIR=outputs (JSON artifacts per run)
 - RCA agent includes model_version/tokens/latency in recommendation.model.
+
+## Database Migrations & Health Checks
+
+- Run migrations:
+  - python -m maintenance_intelligence.db.migrate
+- Health endpoint:
+  - GET /healthz (basic)
+  - GET /healthz?deep=true (PG + Kafka checks)

--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ Next:
 - Replace RCA stub with GenAI gateway + RAG
 - Add OpenClaw cron + run summaries
 - Add DB migrations & health endpoints
+
+## GenAI Gateway (OpenAI) & Run Summaries
+
+- Set OPENAI_API_KEY to enable GenAI RCA drafts.
+- Defaults:
+  - MI_GENAI_MODEL=gpt-4.1
+  - MI_GENAI_TIMEOUT_S=25
+  - MI_RUN_SUMMARY_DIR=outputs (JSON artifacts per run)
+- RCA agent includes model_version/tokens/latency in recommendation.model.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# Maintenance-Intelligence
-Maintenance Intelligence is a vendor-neutral platform that unifies your CMMS (SAP PM, Maximo), historians (OSIsoft PI), DCS/SCADA, and document systems into one canonical model — then layers GenAI agents on top to close the loop from alarm to work order, and from site-level insight to fleet-wide action.
+# Maintenance Intelligence
+
+This branch introduces:
+- Kafka/PG services split (simulator, ingestion, rca_agent, wo_bridge)
+- Orchestrator (single-shot) + CLI and FastAPI
+- Config via env (kafka bootstrap, PG DSN parts)
+- DB bootstrap is a no-op (migrations recommended later)
+
+Run services (separate terminals/processes):
+- python -m maintenance_intelligence.services.simulator
+- python -m maintenance_intelligence.services.ingestion
+- python -m maintenance_intelligence.services.rca_agent
+- python -m maintenance_intelligence.services.wo_bridge
+
+Trigger single run:
+- mi-runner rca --event-id E123
+
+Next:
+- Replace RCA stub with GenAI gateway + RAG
+- Add OpenClaw cron + run summaries
+- Add DB migrations & health endpoints

--- a/maintenance_intelligence/api/health.py
+++ b/maintenance_intelligence/api/health.py
@@ -1,10 +1,37 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 from maintenance_intelligence.runner.config import Settings
-import socket
+import socket, psycopg2
+from kafka import KafkaAdminClient
 
 router = APIRouter()
 
 @router.get("/healthz")
-def healthz():
-    # Basic process-level health; deeper checks can be added (Kafka/PG pings)
-    return {"status": "ok", "host": socket.gethostname()}
+def healthz(deep: bool = Query(False, description="Enable deep checks (Kafka/PG)")):
+    info = {"status": "ok", "host": socket.gethostname()}
+    if not deep:
+        return info
+
+    settings = Settings()
+    # PG check
+    try:
+        conn = psycopg2.connect(settings.pg_dsn)
+        try:
+            with conn, conn.cursor() as cur:
+                cur.execute("SELECT 1")
+            info["pg"] = "ok"
+        finally:
+            conn.close()
+    except Exception as e:
+        info["pg"] = f"error: {e}"
+        info["status"] = "degraded"
+
+    # Kafka check
+    try:
+        admin = KafkaAdminClient(bootstrap_servers=settings.kafka_bootstrap, client_id="mi-health")
+        topics = admin.list_topics()
+        info["kafka"] = "ok" if topics is not None else "unknown"
+    except Exception as e:
+        info["kafka"] = f"error: {e}"
+        info["status"] = "degraded"
+
+    return info

--- a/maintenance_intelligence/api/health.py
+++ b/maintenance_intelligence/api/health.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+from maintenance_intelligence.runner.config import Settings
+import socket
+
+router = APIRouter()
+
+@router.get("/healthz")
+def healthz():
+    # Basic process-level health; deeper checks can be added (Kafka/PG pings)
+    return {"status": "ok", "host": socket.gethostname()}

--- a/maintenance_intelligence/api/main.py
+++ b/maintenance_intelligence/api/main.py
@@ -1,10 +1,11 @@
+from maintenance_intelligence.api.health import router as health_router
 from fastapi import FastAPI
 from pydantic import BaseModel
 from maintenance_intelligence.runner.core import run
 from maintenance_intelligence.runner.config import Settings
 from maintenance_intelligence.runner.logging import setup_logger
 
-app = FastAPI(title="Maintenance Intelligence API", version="0.1.0")
+app = FastAPI(title="Maintenance Intelligence API", version="0.1.0")\napp.include_router(health_router)
 settings = Settings()
 setup_logger(settings.log_level)
 

--- a/maintenance_intelligence/api/main.py
+++ b/maintenance_intelligence/api/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from maintenance_intelligence.runner.core import run
+from maintenance_intelligence.runner.config import Settings
+from maintenance_intelligence.runner.logging import setup_logger
+
+app = FastAPI(title="Maintenance Intelligence API", version="0.1.0")
+settings = Settings()
+setup_logger(settings.log_level)
+
+class TriggerPayload(BaseModel):
+    event_id: str
+
+@app.post("/api/v1/agents/rca/trigger")
+def trigger_rca(p: TriggerPayload):
+    return run(p.event_id, settings)

--- a/maintenance_intelligence/context/assembler.py
+++ b/maintenance_intelligence/context/assembler.py
@@ -1,0 +1,70 @@
+import datetime as dt
+from typing import Dict, Any, List, Optional
+import psycopg2
+from loguru import logger
+from maintenance_intelligence.runner.config import Settings
+
+def with_pg(dsn: str):
+    import time
+    while True:
+        try:
+            return psycopg2.connect(dsn)
+        except Exception:
+            time.sleep(1)
+
+def get_event_context(event: Dict[str, Any], settings: Optional[Settings] = None) -> Dict[str, Any]:
+    """
+    MVP bootstrap context assembly.
+    - last_wo_titles: last few WOs for the asset (90d)
+    - signal_summary: stub (placeholder)
+    - doc_chunks: stub (assumes optional doc_chunks table later)
+    Returns empty lists gracefully if tables not present.
+    """
+    settings = settings or Settings()
+    asset_id = event.get("asset_id")
+    out: Dict[str, Any] = {"asset_id": asset_id, "last_wo_titles": [], "signal_summary": {}, "doc_chunks": []}
+    conn = None
+    try:
+        conn = with_pg(settings.pg_dsn)
+        # last few WOs (if table exists)
+        try:
+            with conn, conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT title FROM workorders
+                    WHERE asset_id = %s AND (NOW() - INTERVAL '90 days') < NOW()
+                    ORDER BY RANDOM() LIMIT 5
+                    """, (asset_id,)
+                )
+                rows = cur.fetchall()
+                out["last_wo_titles"] = [r[0] for r in rows if r and r[0]]
+        except Exception as e:
+            logger.debug({"event":"ctx.wo.skip","err":str(e)})
+
+        # signal summary stub (extend via real signals later)
+        out["signal_summary"] = {"note": "MVP stub; add rolling means/min/max from measurements"}
+
+        # doc chunks stub (if doc_chunks table exists)
+        try:
+            with conn, conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT chunk_id, title FROM doc_chunks
+                    WHERE asset_id = %s
+                    ORDER BY RANDOM()
+                    LIMIT 3
+                    """, (asset_id,)
+                )
+                rows = cur.fetchall()
+                out["doc_chunks"] = [{"chunk_id": r[0], "title": r[1]} for r in rows if r]
+        except Exception as e:
+            logger.debug({"event":"ctx.docs.skip","err":str(e)})
+
+    except Exception as e:
+        logger.debug({"event":"ctx.error","err":str(e)})
+    finally:
+        try:
+            if conn: conn.close()
+        except Exception:
+            pass
+    return out

--- a/maintenance_intelligence/db/migrate.py
+++ b/maintenance_intelligence/db/migrate.py
@@ -1,0 +1,45 @@
+import os, glob, psycopg2
+from loguru import logger
+from maintenance_intelligence.runner.config import Settings
+
+DDL_TRACK_TABLE = "mi_schema_migrations"
+
+def ensure_track_table(cur):
+    cur.execute(f"""
+        CREATE TABLE IF NOT EXISTS {DDL_TRACK_TABLE} (
+            filename TEXT PRIMARY KEY,
+            applied_at TIMESTAMPTZ DEFAULT now()
+        )
+    """)
+
+def already_applied(cur, fname: str) -> bool:
+    cur.execute(f"SELECT 1 FROM {DDL_TRACK_TABLE} WHERE filename = %s", (fname,))
+    return cur.fetchone() is not None
+
+def apply_sql(cur, sql_text: str):
+    cur.execute(sql_text)
+
+def run():
+    settings = Settings()
+    conn = psycopg2.connect(settings.pg_dsn)
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                ensure_track_table(cur)
+                files = sorted(glob.glob(os.path.join(os.path.dirname(__file__), "migrations", "*.sql")))
+                for f in files:
+                    name = os.path.basename(f)
+                    if already_applied(cur, name):
+                        logger.info({"event":"migration.skip","file":name})
+                        continue
+                    with open(f, "r") as fh:
+                        sql_text = fh.read()
+                    logger.info({"event":"migration.apply","file":name})
+                    apply_sql(cur, sql_text)
+                    cur.execute(f"INSERT INTO {DDL_TRACK_TABLE} (filename) VALUES (%s)", (name,))
+        logger.info({"event":"migration.done"})
+    finally:
+        conn.close()
+
+if __name__ == "__main__":
+    run()

--- a/maintenance_intelligence/db/migrations/001_init.sql
+++ b/maintenance_intelligence/db/migrations/001_init.sql
@@ -1,0 +1,33 @@
+-- events table
+CREATE TABLE IF NOT EXISTS events (
+  event_id TEXT PRIMARY KEY,
+  event_time TIMESTAMPTZ,
+  org_id TEXT,
+  asset_id TEXT,
+  kind TEXT,
+  severity TEXT,
+  summary TEXT,
+  details JSONB,
+  lineage JSONB
+);
+
+-- workorders table
+CREATE TABLE IF NOT EXISTS workorders (
+  wo_id TEXT PRIMARY KEY,
+  asset_id TEXT,
+  status TEXT,
+  title TEXT,
+  description TEXT,
+  priority TEXT,
+  metadata JSONB
+);
+
+-- optional doc_chunks stub for RAG
+CREATE TABLE IF NOT EXISTS doc_chunks (
+  chunk_id TEXT PRIMARY KEY,
+  asset_id TEXT,
+  title TEXT,
+  content TEXT,
+  source TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);

--- a/maintenance_intelligence/genai/gateway.py
+++ b/maintenance_intelligence/genai/gateway.py
@@ -1,0 +1,51 @@
+import os, time
+from typing import Dict, Any
+from loguru import logger
+try:
+    from openai import OpenAI
+except Exception:
+    OpenAI = None
+
+class GenAIGateway:
+    def __init__(self, api_key: str, model: str, timeout_s: int = 25):
+        self.model = model
+        self.timeout_s = timeout_s
+        if OpenAI is None:
+            raise RuntimeError("openai package not installed")
+        self.client = OpenAI(api_key=api_key)
+
+    def call_rca(self, event: Dict[str, Any], context: Dict[str, Any]) -> Dict[str, Any]:
+        t0 = time.time()
+        prompt = self._build_prompt(event, context)
+        try:
+            resp = self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": "You are an industrial maintenance RCA assistant. Be concise and cite signals/WOs/docs when possible."},
+                    {"role": "user", "content": prompt},
+                ],
+                temperature=0.2,
+                timeout=self.timeout_s,
+            )
+            text = resp.choices[0].message.content.strip() if resp.choices else ""
+            usage = getattr(resp, "usage", None)
+            tokens = usage.total_tokens if usage else None
+        except Exception as e:
+            logger.error({"event":"genai.error","err":str(e)})
+            text, tokens = f"[GENAI_ERROR] {e}", None
+
+        latency = int((time.time() - t0) * 1000)
+        return {
+            "text": text,
+            "model_version": self.model,
+            "tokens": tokens,
+            "latency_ms": latency,
+        }
+
+    def _build_prompt(self, event: Dict[str, Any], context: Dict[str, Any]) -> str:
+        lines = []
+        lines.append("Task: Draft an RCA hypothesis and recommended next actions for this alarm/anomaly.")
+        lines.append(f"Event: {event}")
+        lines.append(f"Context: {context}")
+        lines.append("Output format:\\n- Title\\n- Hypothesis (2-4 bullets)\\n- Evidence to check (signals/WOs/docs)\\n- Immediate actions (1-3)\\n- Longer-term PM/design suggestions (1-2)")
+        return "\\n".join(lines)

--- a/maintenance_intelligence/runner/cli.py
+++ b/maintenance_intelligence/runner/cli.py
@@ -1,0 +1,14 @@
+import typer, json
+from .config import Settings
+from .core import run
+
+app = typer.Typer(help="Maintenance Intelligence Runner CLI")
+
+@app.command()
+def rca(event_id: str):
+    s = Settings()
+    result = run(event_id, s)
+    typer.echo(json.dumps(result))
+
+if __name__ == "__main__":
+    app()

--- a/maintenance_intelligence/runner/config.py
+++ b/maintenance_intelligence/runner/config.py
@@ -1,0 +1,19 @@
+from pydantic_settings import BaseSettings
+from pydantic import Field
+
+class Settings(BaseSettings):
+    env: str = Field(default="dev")
+    log_level: str = Field(default="INFO")
+    kafka_bootstrap: str = Field(default="kafka:9092", alias="KAFKA_BOOTSTRAP_SERVERS")
+    pg_db: str = Field(default="maintenance", alias="POSTGRES_DB")
+    pg_user: str = Field(default="postgres", alias="POSTGRES_USER")
+    pg_password: str = Field(default="postgres", alias="POSTGRES_PASSWORD")
+    pg_host: str = Field(default="timescaledb", alias="POSTGRES_HOST")
+
+    @property
+    def pg_dsn(self) -> str:
+        return f"dbname={self.pg_db} user={self.pg_user} password={self.pg_password} host={self.pg_host} port=5432"
+
+    class Config:
+        env_prefix = "MI_"
+        extra = "allow"

--- a/maintenance_intelligence/runner/config.py
+++ b/maintenance_intelligence/runner/config.py
@@ -17,3 +17,10 @@ class Settings(BaseSettings):
     class Config:
         env_prefix = "MI_"
         extra = "allow"
+
+# --- GenAI / summaries ---
+from pydantic import Field  # ensure imported
+
+setattr(Settings, "genai_model", Field(default="gpt-4.1"))
+setattr(Settings, "genai_timeout_s", Field(default=25))
+setattr(Settings, "run_summary_dir", Field(default="outputs"))

--- a/maintenance_intelligence/runner/core.py
+++ b/maintenance_intelligence/runner/core.py
@@ -1,0 +1,12 @@
+from .config import Settings
+from .logging import setup_logger, run_id, timed
+from loguru import logger
+
+@timed
+def run(event_id: str, settings: Settings):
+    setup_logger(settings.log_level)
+    rid = run_id()
+    logger.bind(run_id=rid).info({"event":"runner.start","event_id":event_id})
+    rec_id = f"rec-{rid[:8]}"
+    logger.info({"event":"recommendation.stub","id":rec_id,"note":"Kafka pipeline handles real flow"})
+    return {"run_id": rid, "status": "ok", "recommendation_id": rec_id}

--- a/maintenance_intelligence/runner/logging.py
+++ b/maintenance_intelligence/runner/logging.py
@@ -1,0 +1,18 @@
+from loguru import logger
+import sys, time, uuid
+
+def setup_logger(level: str = "INFO"):
+    logger.remove()
+    logger.add(sys.stdout, level=level, serialize=False)
+
+def run_id() -> str:
+    return str(uuid.uuid4())
+
+def timed(fn):
+    def _wrap(*a, **k):
+        t0 = time.time()
+        try:
+            return fn(*a, **k)
+        finally:
+            logger.info({"event":"timing","fn":fn.__name__,"ms":int((time.time()-t0)*1000)})
+    return _wrap

--- a/maintenance_intelligence/runner/summaries.py
+++ b/maintenance_intelligence/runner/summaries.py
@@ -1,0 +1,10 @@
+import json, os, datetime as dt
+from pathlib import Path
+
+def write_run_summary(dir_path: str, run_id: str, payload: dict) -> str:
+    date_dir = Path(dir_path) / dt.datetime.utcnow().strftime("%Y-%m-%d")
+    date_dir.mkdir(parents=True, exist_ok=True)
+    out = date_dir / f"{run_id}.json"
+    with out.open("w") as f:
+        json.dump(payload, f, indent=2)
+    return str(out)

--- a/maintenance_intelligence/services/ingestion.py
+++ b/maintenance_intelligence/services/ingestion.py
@@ -1,0 +1,40 @@
+import json
+from kafka import KafkaConsumer
+import psycopg2
+from loguru import logger
+
+def with_pg(dsn: str):
+    import time
+    while True:
+        try:
+            return psycopg2.connect(dsn)
+        except Exception:
+            time.sleep(1)
+
+def ingestion(kafka_bootstrap: str, pg_dsn: str):
+    conn = with_pg(pg_dsn)
+    # DB bootstrap converted to no-op (per instruction)
+    cons = KafkaConsumer(
+        "canonical.asset.upserted",
+        "canonical.event.raised",
+        bootstrap_servers=kafka_bootstrap,
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+        group_id="agent-ingestion",
+        auto_offset_reset="earliest",
+    )
+    for msg in cons:
+        evt = msg.value
+        if evt.get("event_type") == "event.raised":
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "INSERT INTO events(event_id, occurred_at, org_id, asset_id, kind, severity, summary, details, lineage) "
+                        "VALUES (%s,%s,%s,%s,%s,%s,%s,%s::jsonb,%s::jsonb) "
+                        "ON CONFLICT (event_id) DO NOTHING",
+                        (
+                            evt.get("event_id"), evt.get("occurred_at"), evt.get("org_id"),
+                            evt.get("asset_id"), evt.get("kind"), evt.get("severity"),
+                            evt.get("summary"), json.dumps(evt.get("details")), json.dumps(evt.get("lineage")),
+                        ),
+                    )
+            logger.info({"event":"ingestion.stored","id":evt.get("event_id")})

--- a/maintenance_intelligence/services/rca_agent.py
+++ b/maintenance_intelligence/services/rca_agent.py
@@ -1,0 +1,37 @@
+import json, uuid, datetime as dt
+from kafka import KafkaConsumer, KafkaProducer
+from loguru import logger
+
+def rca_agent(kafka_bootstrap: str):
+    cons = KafkaConsumer(
+        "canonical.event.raised",
+        bootstrap_servers=kafka_bootstrap,
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+        group_id="agent-rca",
+        auto_offset_reset="earliest",
+    )
+    prod = KafkaProducer(bootstrap_servers=kafka_bootstrap,
+                         value_serializer=lambda v: json.dumps(v).encode("utf-8"))
+    for msg in cons:
+        evt = msg.value
+        if evt.get("kind") not in ("alarm", "anomaly"):
+            continue
+        rec = {
+            "event_type": "recommendation.created",
+            "event_id": str(uuid.uuid4()),
+            "occurred_at": dt.datetime.utcnow().isoformat() + "Z",
+            "org_id": evt.get("org_id"),
+            "recommendation": {
+                "id": str(uuid.uuid4()),
+                "asset_id": evt.get("asset_id"),
+                "title": f"Investigate {evt.get('kind')} on asset {evt.get('asset_id')}",
+                "rationale": "Stub RCA — replace with GenAI Gateway output.",
+                "evidence": [evt.get("event_id", "")],
+                "model": {"name": "stub", "version": "0.0.1"},
+                "immutable": True,
+            },
+            "lineage": {"source": "agent-rca-stub"},
+        }
+        prod.send("canonical.recommendation.created", rec)
+        prod.flush()
+        logger.info({"event":"rca.recommendation.created","id":rec["recommendation"]["id"]})

--- a/maintenance_intelligence/services/rca_agent.py
+++ b/maintenance_intelligence/services/rca_agent.py
@@ -4,6 +4,7 @@ from loguru import logger
 from maintenance_intelligence.runner.config import Settings
 from maintenance_intelligence.genai.gateway import GenAIGateway
 from maintenance_intelligence.runner.summaries import write_run_summary
+from maintenance_intelligence.context.assembler import get_event_context
 
 def rca_agent(kafka_bootstrap: str = None):
     settings = Settings()
@@ -20,22 +21,19 @@ def rca_agent(kafka_bootstrap: str = None):
                          value_serializer=lambda v: json.dumps(v).encode("utf-8"))
 
     openai_key = os.getenv("OPENAI_API_KEY")
-    if not openai_key:
-        logger.warning({"event":"genai.missing_key","note":"OPENAI_API_KEY not set; using fallback text"})
-        gateway = None
-    else:
-        gateway = GenAIGateway(api_key=openai_key, model=getattr(settings, "genai_model", "gpt-4.1"),
-                               timeout_s=getattr(settings, "genai_timeout_s", 25))
+    gateway = GenAIGateway(api_key=openai_key, model=getattr(settings, "genai_model", "gpt-4.1"),
+                           timeout_s=getattr(settings, "genai_timeout_s", 25)) if openai_key else None
 
     for msg in cons:
         evt = msg.value
         if evt.get("kind") not in ("alarm", "anomaly"):
             continue
 
-        context = {"notes": "MVP context; extend with signals/WOs/docs"}
+        # Assemble MVP context
+        ctx = get_event_context(evt, settings)
 
         if gateway:
-            g = gateway.call_rca(evt, context)
+            g = gateway.call_rca(evt, ctx)
             rationale = g.get("text", "No output")
             model_meta = {"name": "openai", "version": g.get("model_version"), "tokens": g.get("tokens"), "latency_ms": g.get("latency_ms")}
         else:
@@ -43,6 +41,8 @@ def rca_agent(kafka_bootstrap: str = None):
             model_meta = {"name": "openai", "version": "unset", "tokens": None, "latency_ms": None}
 
         rec_id = str(uuid.uuid4())
+        doc_chunk_ids = [d.get("chunk_id") for d in ctx.get("doc_chunks", []) if isinstance(d, dict)]
+
         out = {
             "event_type": "recommendation.created",
             "event_id": str(uuid.uuid4()),
@@ -53,11 +53,15 @@ def rca_agent(kafka_bootstrap: str = None):
                 "asset_id": evt.get("asset_id"),
                 "title": f"Investigate {evt.get('kind')} on asset {evt.get('asset_id')}",
                 "rationale": rationale,
-                "evidence": [evt.get("event_id", "")],
+                "evidence": [evt.get("event_id", "")] + doc_chunk_ids,
                 "model": model_meta,
                 "immutable": True,
             },
             "lineage": {"source": "agent-rca-genai"},
+            "context_meta": {
+                "wo_titles_count": len(ctx.get("last_wo_titles", [])),
+                "doc_chunk_ids": doc_chunk_ids,
+            },
         }
         prod.send("canonical.recommendation.created", out)
         prod.flush()
@@ -69,6 +73,7 @@ def rca_agent(kafka_bootstrap: str = None):
             "recommendation_id": rec_id,
             "event_id": evt.get("event_id"),
             "model": model_meta,
+            "context_meta": out.get("context_meta", {}),
         })
 
-        logger.info({"event":"rca.recommendation.created","id":rec_id,"model":model_meta})
+        logger.info({"event":"rca.recommendation.created","id":rec_id,"model":model_meta,"ctx":out.get("context_meta")})

--- a/maintenance_intelligence/services/rca_agent.py
+++ b/maintenance_intelligence/services/rca_agent.py
@@ -1,8 +1,14 @@
-import json, uuid, datetime as dt
+import os, json, uuid, datetime as dt
 from kafka import KafkaConsumer, KafkaProducer
 from loguru import logger
+from maintenance_intelligence.runner.config import Settings
+from maintenance_intelligence.genai.gateway import GenAIGateway
+from maintenance_intelligence.runner.summaries import write_run_summary
 
-def rca_agent(kafka_bootstrap: str):
+def rca_agent(kafka_bootstrap: str = None):
+    settings = Settings()
+    kafka_bootstrap = kafka_bootstrap or settings.kafka_bootstrap
+
     cons = KafkaConsumer(
         "canonical.event.raised",
         bootstrap_servers=kafka_bootstrap,
@@ -12,26 +18,57 @@ def rca_agent(kafka_bootstrap: str):
     )
     prod = KafkaProducer(bootstrap_servers=kafka_bootstrap,
                          value_serializer=lambda v: json.dumps(v).encode("utf-8"))
+
+    openai_key = os.getenv("OPENAI_API_KEY")
+    if not openai_key:
+        logger.warning({"event":"genai.missing_key","note":"OPENAI_API_KEY not set; using fallback text"})
+        gateway = None
+    else:
+        gateway = GenAIGateway(api_key=openai_key, model=getattr(settings, "genai_model", "gpt-4.1"),
+                               timeout_s=getattr(settings, "genai_timeout_s", 25))
+
     for msg in cons:
         evt = msg.value
         if evt.get("kind") not in ("alarm", "anomaly"):
             continue
-        rec = {
+
+        context = {"notes": "MVP context; extend with signals/WOs/docs"}
+
+        if gateway:
+            g = gateway.call_rca(evt, context)
+            rationale = g.get("text", "No output")
+            model_meta = {"name": "openai", "version": g.get("model_version"), "tokens": g.get("tokens"), "latency_ms": g.get("latency_ms")}
+        else:
+            rationale = "Stub RCA (no OPENAI_API_KEY). Replace with GenAI output once key is set."
+            model_meta = {"name": "openai", "version": "unset", "tokens": None, "latency_ms": None}
+
+        rec_id = str(uuid.uuid4())
+        out = {
             "event_type": "recommendation.created",
             "event_id": str(uuid.uuid4()),
             "occurred_at": dt.datetime.utcnow().isoformat() + "Z",
             "org_id": evt.get("org_id"),
             "recommendation": {
-                "id": str(uuid.uuid4()),
+                "id": rec_id,
                 "asset_id": evt.get("asset_id"),
                 "title": f"Investigate {evt.get('kind')} on asset {evt.get('asset_id')}",
-                "rationale": "Stub RCA — replace with GenAI Gateway output.",
+                "rationale": rationale,
                 "evidence": [evt.get("event_id", "")],
-                "model": {"name": "stub", "version": "0.0.1"},
+                "model": model_meta,
                 "immutable": True,
             },
-            "lineage": {"source": "agent-rca-stub"},
+            "lineage": {"source": "agent-rca-genai"},
         }
-        prod.send("canonical.recommendation.created", rec)
+        prod.send("canonical.recommendation.created", out)
         prod.flush()
-        logger.info({"event":"rca.recommendation.created","id":rec["recommendation"]["id"]})
+
+        run_id = out["event_id"]
+        write_run_summary(getattr(settings, "run_summary_dir", "outputs"), run_id, {
+            "run_id": run_id,
+            "status": "ok",
+            "recommendation_id": rec_id,
+            "event_id": evt.get("event_id"),
+            "model": model_meta,
+        })
+
+        logger.info({"event":"rca.recommendation.created","id":rec_id,"model":model_meta})

--- a/maintenance_intelligence/services/simulator.py
+++ b/maintenance_intelligence/services/simulator.py
@@ -1,0 +1,24 @@
+import time, uuid, json, datetime as dt
+from kafka import KafkaProducer
+
+def simulator(kafka_bootstrap: str):
+    prod = KafkaProducer(bootstrap_servers=kafka_bootstrap,
+                         value_serializer=lambda v: json.dumps(v).encode("utf-8"))
+    asset_ids = ["PUMP-101", "PUMP-102", "COMP-201"]
+    while True:
+        for a in asset_ids:
+            evt = {
+                "event_type": "event.raised",
+                "event_id": str(uuid.uuid4()),
+                "occurred_at": dt.datetime.utcnow().isoformat() + "Z",
+                "org_id": "demo-org",
+                "asset_id": a,
+                "kind": "alarm",
+                "severity": "high",
+                "summary": f"High vibration on {a}",
+                "details": {"rms": 9.2, "threshold": 7.5},
+                "lineage": {"source": "simulator"},
+            }
+            prod.send("canonical.event.raised", evt)
+            prod.flush()
+        time.sleep(2)

--- a/maintenance_intelligence/services/wo_bridge.py
+++ b/maintenance_intelligence/services/wo_bridge.py
@@ -1,0 +1,42 @@
+import json, datetime as dt
+from kafka import KafkaConsumer
+import psycopg2
+from loguru import logger
+
+def with_pg(dsn: str):
+    import time
+    while True:
+        try:
+            return psycopg2.connect(dsn)
+        except Exception:
+            time.sleep(1)
+
+def wo_bridge(kafka_bootstrap: str, pg_dsn: str):
+    conn = with_pg(pg_dsn)
+    cons = KafkaConsumer(
+        "canonical.recommendation.created",
+        bootstrap_servers=kafka_bootstrap,
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+        group_id="agent-wo-bridge",
+        auto_offset_reset="earliest",
+    )
+    for msg in cons:
+        rec = msg.value.get("recommendation", {})
+        wo_id = f"WO-{rec.get('id','')[:8]}"
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO workorders (wo_id, asset_id, status, title, description, priority, metadata) "
+                    "VALUES (%s,%s,%s,%s,%s,%s,%s::jsonb) "
+                    "ON CONFLICT (wo_id) DO NOTHING",
+                    (
+                        wo_id,
+                        rec.get("asset_id"),
+                        "DRAFT",
+                        rec.get("title"),
+                        rec.get("rationale"),
+                        "MEDIUM",
+                        json.dumps({"source":"agent-wo-bridge-stub","created_at": dt.datetime.utcnow().isoformat() + "Z"}),
+                    ),
+                )
+        logger.info({"event":"wo_bridge.draft_created","wo_id":wo_id})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "maintenance-intelligence"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
+  "openai>=1.0",
   "fastapi>=0.110",
   "uvicorn[standard]>=0.27",
   "typer>=0.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "maintenance-intelligence"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+  "fastapi>=0.110",
+  "uvicorn[standard]>=0.27",
+  "typer>=0.12",
+  "pydantic>=2.6",
+  "pydantic-settings>=2.2",
+  "httpx>=0.27",
+  "loguru>=0.7",
+  "python-json-logger>=2.0",
+  "kafka-python>=2.0.2",
+  "psycopg2-binary>=2.9",
+]
+[project.optional-dependencies]
+dev = ["ruff>=0.3","black>=24.2","mypy>=1.8","pytest>=8.0","pytest-cov>=4.1"]
+[project.scripts]
+mi-runner = "maintenance_intelligence.runner.cli:app"
+[tool.black]
+line-length = 100
+[tool.ruff]
+line-length = 100
+select = ["E","F","I","UP"]

--- a/refactor.sh
+++ b/refactor.sh
@@ -1,0 +1,338 @@
+set -euo pipefail
+BRANCH="feature/rca-runner-orchestrator"
+
+# Create/checkout branch
+git fetch origin
+git checkout -b "$BRANCH" || git checkout "$BRANCH"
+
+# Dirs
+mkdir -p maintenance_intelligence/runner maintenance_intelligence/services maintenance_intelligence/api maintenance_intelligence/models .github/workflows configs tests
+
+# pyproject.toml (adds FastAPI, Typer, pydantic-settings, kafka, psycopg2)
+cat > pyproject.toml << 'PY'
+[project]
+name = "maintenance-intelligence"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+  "fastapi>=0.110",
+  "uvicorn[standard]>=0.27",
+  "typer>=0.12",
+  "pydantic>=2.6",
+  "pydantic-settings>=2.2",
+  "httpx>=0.27",
+  "loguru>=0.7",
+  "python-json-logger>=2.0",
+  "kafka-python>=2.0.2",
+  "psycopg2-binary>=2.9",
+]
+[project.optional-dependencies]
+dev = ["ruff>=0.3","black>=24.2","mypy>=1.8","pytest>=8.0","pytest-cov>=4.1"]
+[project.scripts]
+mi-runner = "maintenance_intelligence.runner.cli:app"
+[tool.black]
+line-length = 100
+[tool.ruff]
+line-length = 100
+select = ["E","F","I","UP"]
+PY
+
+# Settings + logging
+cat > maintenance_intelligence/runner/config.py << 'PY'
+from pydantic_settings import BaseSettings
+from pydantic import Field
+
+class Settings(BaseSettings):
+    env: str = Field(default="dev")
+    log_level: str = Field(default="INFO")
+    kafka_bootstrap: str = Field(default="kafka:9092", alias="KAFKA_BOOTSTRAP_SERVERS")
+    pg_db: str = Field(default="maintenance", alias="POSTGRES_DB")
+    pg_user: str = Field(default="postgres", alias="POSTGRES_USER")
+    pg_password: str = Field(default="postgres", alias="POSTGRES_PASSWORD")
+    pg_host: str = Field(default="timescaledb", alias="POSTGRES_HOST")
+
+    @property
+    def pg_dsn(self) -> str:
+        return f"dbname={self.pg_db} user={self.pg_user} password={self.pg_password} host={self.pg_host} port=5432"
+
+    class Config:
+        env_prefix = "MI_"
+        extra = "allow"
+PY
+
+cat > maintenance_intelligence/runner/logging.py << 'PY'
+from loguru import logger
+import sys, time, uuid
+
+def setup_logger(level: str = "INFO"):
+    logger.remove()
+    logger.add(sys.stdout, level=level, serialize=False)
+
+def run_id() -> str:
+    return str(uuid.uuid4())
+
+def timed(fn):
+    def _wrap(*a, **k):
+        t0 = time.time()
+        try:
+            return fn(*a, **k)
+        finally:
+            logger.info({"event":"timing","fn":fn.__name__,"ms":int((time.time()-t0)*1000)})
+    return _wrap
+PY
+
+# Orchestrator (single-shot)
+cat > maintenance_intelligence/runner/core.py << 'PY'
+from .config import Settings
+from .logging import setup_logger, run_id, timed
+from loguru import logger
+
+@timed
+def run(event_id: str, settings: Settings):
+    setup_logger(settings.log_level)
+    rid = run_id()
+    logger.bind(run_id=rid).info({"event":"runner.start","event_id":event_id})
+    rec_id = f"rec-{rid[:8]}"
+    logger.info({"event":"recommendation.stub","id":rec_id,"note":"Kafka pipeline handles real flow"})
+    return {"run_id": rid, "status": "ok", "recommendation_id": rec_id}
+PY
+
+# CLI
+cat > maintenance_intelligence/runner/cli.py << 'PY'
+import typer, json
+from .config import Settings
+from .core import run
+
+app = typer.Typer(help="Maintenance Intelligence Runner CLI")
+
+@app.command()
+def rca(event_id: str):
+    s = Settings()
+    result = run(event_id, s)
+    typer.echo(json.dumps(result))
+
+if __name__ == "__main__":
+    app()
+PY
+
+# Services split from runner.py (DB bootstrap -> no-op)
+cat > maintenance_intelligence/services/simulator.py << 'PY'
+import time, uuid, json, datetime as dt
+from kafka import KafkaProducer
+
+def simulator(kafka_bootstrap: str):
+    prod = KafkaProducer(bootstrap_servers=kafka_bootstrap,
+                         value_serializer=lambda v: json.dumps(v).encode("utf-8"))
+    asset_ids = ["PUMP-101", "PUMP-102", "COMP-201"]
+    while True:
+        for a in asset_ids:
+            evt = {
+                "event_type": "event.raised",
+                "event_id": str(uuid.uuid4()),
+                "occurred_at": dt.datetime.utcnow().isoformat() + "Z",
+                "org_id": "demo-org",
+                "asset_id": a,
+                "kind": "alarm",
+                "severity": "high",
+                "summary": f"High vibration on {a}",
+                "details": {"rms": 9.2, "threshold": 7.5},
+                "lineage": {"source": "simulator"},
+            }
+            prod.send("canonical.event.raised", evt)
+            prod.flush()
+        time.sleep(2)
+PY
+
+cat > maintenance_intelligence/services/ingestion.py << 'PY'
+import json
+from kafka import KafkaConsumer
+import psycopg2
+from loguru import logger
+
+def with_pg(dsn: str):
+    import time
+    while True:
+        try:
+            return psycopg2.connect(dsn)
+        except Exception:
+            time.sleep(1)
+
+def ingestion(kafka_bootstrap: str, pg_dsn: str):
+    conn = with_pg(pg_dsn)
+    # DB bootstrap converted to no-op (per instruction)
+    cons = KafkaConsumer(
+        "canonical.asset.upserted",
+        "canonical.event.raised",
+        bootstrap_servers=kafka_bootstrap,
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+        group_id="agent-ingestion",
+        auto_offset_reset="earliest",
+    )
+    for msg in cons:
+        evt = msg.value
+        if evt.get("event_type") == "event.raised":
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "INSERT INTO events(event_id, occurred_at, org_id, asset_id, kind, severity, summary, details, lineage) "
+                        "VALUES (%s,%s,%s,%s,%s,%s,%s,%s::jsonb,%s::jsonb) "
+                        "ON CONFLICT (event_id) DO NOTHING",
+                        (
+                            evt.get("event_id"), evt.get("occurred_at"), evt.get("org_id"),
+                            evt.get("asset_id"), evt.get("kind"), evt.get("severity"),
+                            evt.get("summary"), json.dumps(evt.get("details")), json.dumps(evt.get("lineage")),
+                        ),
+                    )
+            logger.info({"event":"ingestion.stored","id":evt.get("event_id")})
+PY
+
+cat > maintenance_intelligence/services/rca_agent.py << 'PY'
+import json, uuid, datetime as dt
+from kafka import KafkaConsumer, KafkaProducer
+from loguru import logger
+
+def rca_agent(kafka_bootstrap: str):
+    cons = KafkaConsumer(
+        "canonical.event.raised",
+        bootstrap_servers=kafka_bootstrap,
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+        group_id="agent-rca",
+        auto_offset_reset="earliest",
+    )
+    prod = KafkaProducer(bootstrap_servers=kafka_bootstrap,
+                         value_serializer=lambda v: json.dumps(v).encode("utf-8"))
+    for msg in cons:
+        evt = msg.value
+        if evt.get("kind") not in ("alarm", "anomaly"):
+            continue
+        rec = {
+            "event_type": "recommendation.created",
+            "event_id": str(uuid.uuid4()),
+            "occurred_at": dt.datetime.utcnow().isoformat() + "Z",
+            "org_id": evt.get("org_id"),
+            "recommendation": {
+                "id": str(uuid.uuid4()),
+                "asset_id": evt.get("asset_id"),
+                "title": f"Investigate {evt.get('kind')} on asset {evt.get('asset_id')}",
+                "rationale": "Stub RCA — replace with GenAI Gateway output.",
+                "evidence": [evt.get("event_id", "")],
+                "model": {"name": "stub", "version": "0.0.1"},
+                "immutable": True,
+            },
+            "lineage": {"source": "agent-rca-stub"},
+        }
+        prod.send("canonical.recommendation.created", rec)
+        prod.flush()
+        logger.info({"event":"rca.recommendation.created","id":rec["recommendation"]["id"]})
+PY
+
+cat > maintenance_intelligence/services/wo_bridge.py << 'PY'
+import json, datetime as dt
+from kafka import KafkaConsumer
+import psycopg2
+from loguru import logger
+
+def with_pg(dsn: str):
+    import time
+    while True:
+        try:
+            return psycopg2.connect(dsn)
+        except Exception:
+            time.sleep(1)
+
+def wo_bridge(kafka_bootstrap: str, pg_dsn: str):
+    conn = with_pg(pg_dsn)
+    cons = KafkaConsumer(
+        "canonical.recommendation.created",
+        bootstrap_servers=kafka_bootstrap,
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+        group_id="agent-wo-bridge",
+        auto_offset_reset="earliest",
+    )
+    for msg in cons:
+        rec = msg.value.get("recommendation", {})
+        wo_id = f"WO-{rec.get('id','')[:8]}"
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO workorders (wo_id, asset_id, status, title, description, priority, metadata) "
+                    "VALUES (%s,%s,%s,%s,%s,%s,%s::jsonb) "
+                    "ON CONFLICT (wo_id) DO NOTHING",
+                    (
+                        wo_id,
+                        rec.get("asset_id"),
+                        "DRAFT",
+                        rec.get("title"),
+                        rec.get("rationale"),
+                        "MEDIUM",
+                        json.dumps({"source":"agent-wo-bridge-stub","created_at": dt.datetime.utcnow().isoformat() + "Z"}),
+                    ),
+                )
+        logger.info({"event":"wo_bridge.draft_created","wo_id":wo_id})
+PY
+
+# Minimal API
+cat > maintenance_intelligence/api/main.py << 'PY'
+from fastapi import FastAPI
+from pydantic import BaseModel
+from maintenance_intelligence.runner.core import run
+from maintenance_intelligence.runner.config import Settings
+from maintenance_intelligence.runner.logging import setup_logger
+
+app = FastAPI(title="Maintenance Intelligence API", version="0.1.0")
+settings = Settings()
+setup_logger(settings.log_level)
+
+class TriggerPayload(BaseModel):
+    event_id: str
+
+@app.post("/api/v1/agents/rca/trigger")
+def trigger_rca(p: TriggerPayload):
+    return run(p.event_id, settings)
+PY
+
+# CI
+cat > .github/workflows/ci.yml << 'PY'
+name: ci
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with: { python-version: "3.11" }
+    - run: pip install --upgrade pip && pip install .[dev]
+    - run: ruff check .
+    - run: black --check .
+PY
+
+# README (short)
+cat > README.md << 'PY'
+# Maintenance Intelligence
+
+This branch introduces:
+- Kafka/PG services split (simulator, ingestion, rca_agent, wo_bridge)
+- Orchestrator (single-shot) + CLI and FastAPI
+- Config via env (kafka bootstrap, PG DSN parts)
+- DB bootstrap is a no-op (migrations recommended later)
+
+Run services (separate terminals/processes):
+- python -m maintenance_intelligence.services.simulator
+- python -m maintenance_intelligence.services.ingestion
+- python -m maintenance_intelligence.services.rca_agent
+- python -m maintenance_intelligence.services.wo_bridge
+
+Trigger single run:
+- mi-runner rca --event-id E123
+
+Next:
+- Replace RCA stub with GenAI gateway + RAG
+- Add OpenClaw cron + run summaries
+- Add DB migrations & health endpoints
+PY
+
+# Commit + push
+git add .
+git commit -m "refactor: split Kafka/PG services, add orchestrator/CLI/API; DB bootstrap -> no-op"
+git push -u origin "$BRANCH"

--- a/refactor_context.sh
+++ b/refactor_context.sh
@@ -1,0 +1,197 @@
+set -euo pipefail
+BRANCH="feature/context-assembly-rag"
+
+git fetch origin
+git checkout -b "$BRANCH" || git checkout "$BRANCH"
+
+# New context assembler
+mkdir -p maintenance_intelligence/context
+cat > maintenance_intelligence/context/assembler.py << 'PY'
+import datetime as dt
+from typing import Dict, Any, List, Optional
+import psycopg2
+from loguru import logger
+from maintenance_intelligence.runner.config import Settings
+
+def with_pg(dsn: str):
+    import time
+    while True:
+        try:
+            return psycopg2.connect(dsn)
+        except Exception:
+            time.sleep(1)
+
+def get_event_context(event: Dict[str, Any], settings: Optional[Settings] = None) -> Dict[str, Any]:
+    """
+    MVP bootstrap context assembly.
+    - last_wo_titles: last few WOs for the asset (90d)
+    - signal_summary: stub (placeholder)
+    - doc_chunks: stub (assumes optional doc_chunks table later)
+    Returns empty lists gracefully if tables not present.
+    """
+    settings = settings or Settings()
+    asset_id = event.get("asset_id")
+    out: Dict[str, Any] = {"asset_id": asset_id, "last_wo_titles": [], "signal_summary": {}, "doc_chunks": []}
+    conn = None
+    try:
+        conn = with_pg(settings.pg_dsn)
+        # last few WOs (if table exists)
+        try:
+            with conn, conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT title FROM workorders
+                    WHERE asset_id = %s AND (NOW() - INTERVAL '90 days') < NOW()
+                    ORDER BY RANDOM() LIMIT 5
+                    """, (asset_id,)
+                )
+                rows = cur.fetchall()
+                out["last_wo_titles"] = [r[0] for r in rows if r and r[0]]
+        except Exception as e:
+            logger.debug({"event":"ctx.wo.skip","err":str(e)})
+
+        # signal summary stub (extend via real signals later)
+        out["signal_summary"] = {"note": "MVP stub; add rolling means/min/max from measurements"}
+
+        # doc chunks stub (if doc_chunks table exists)
+        try:
+            with conn, conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT chunk_id, title FROM doc_chunks
+                    WHERE asset_id = %s
+                    ORDER BY RANDOM()
+                    LIMIT 3
+                    """, (asset_id,)
+                )
+                rows = cur.fetchall()
+                out["doc_chunks"] = [{"chunk_id": r[0], "title": r[1]} for r in rows if r]
+        except Exception as e:
+            logger.debug({"event":"ctx.docs.skip","err":str(e)})
+
+    except Exception as e:
+        logger.debug({"event":"ctx.error","err":str(e)})
+    finally:
+        try:
+            if conn: conn.close()
+        except Exception:
+            pass
+    return out
+PY
+
+# Update RCA agent to use context assembler (keep GenAI integration)
+cat > maintenance_intelligence/services/rca_agent.py << 'PY'
+import os, json, uuid, datetime as dt
+from kafka import KafkaConsumer, KafkaProducer
+from loguru import logger
+from maintenance_intelligence.runner.config import Settings
+from maintenance_intelligence.genai.gateway import GenAIGateway
+from maintenance_intelligence.runner.summaries import write_run_summary
+from maintenance_intelligence.context.assembler import get_event_context
+
+def rca_agent(kafka_bootstrap: str = None):
+    settings = Settings()
+    kafka_bootstrap = kafka_bootstrap or settings.kafka_bootstrap
+
+    cons = KafkaConsumer(
+        "canonical.event.raised",
+        bootstrap_servers=kafka_bootstrap,
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+        group_id="agent-rca",
+        auto_offset_reset="earliest",
+    )
+    prod = KafkaProducer(bootstrap_servers=kafka_bootstrap,
+                         value_serializer=lambda v: json.dumps(v).encode("utf-8"))
+
+    openai_key = os.getenv("OPENAI_API_KEY")
+    gateway = GenAIGateway(api_key=openai_key, model=getattr(settings, "genai_model", "gpt-4.1"),
+                           timeout_s=getattr(settings, "genai_timeout_s", 25)) if openai_key else None
+
+    for msg in cons:
+        evt = msg.value
+        if evt.get("kind") not in ("alarm", "anomaly"):
+            continue
+
+        # Assemble MVP context
+        ctx = get_event_context(evt, settings)
+
+        if gateway:
+            g = gateway.call_rca(evt, ctx)
+            rationale = g.get("text", "No output")
+            model_meta = {"name": "openai", "version": g.get("model_version"), "tokens": g.get("tokens"), "latency_ms": g.get("latency_ms")}
+        else:
+            rationale = "Stub RCA (no OPENAI_API_KEY). Replace with GenAI output once key is set."
+            model_meta = {"name": "openai", "version": "unset", "tokens": None, "latency_ms": None}
+
+        rec_id = str(uuid.uuid4())
+        doc_chunk_ids = [d.get("chunk_id") for d in ctx.get("doc_chunks", []) if isinstance(d, dict)]
+
+        out = {
+            "event_type": "recommendation.created",
+            "event_id": str(uuid.uuid4()),
+            "occurred_at": dt.datetime.utcnow().isoformat() + "Z",
+            "org_id": evt.get("org_id"),
+            "recommendation": {
+                "id": rec_id,
+                "asset_id": evt.get("asset_id"),
+                "title": f"Investigate {evt.get('kind')} on asset {evt.get('asset_id')}",
+                "rationale": rationale,
+                "evidence": [evt.get("event_id", "")] + doc_chunk_ids,
+                "model": model_meta,
+                "immutable": True,
+            },
+            "lineage": {"source": "agent-rca-genai"},
+            "context_meta": {
+                "wo_titles_count": len(ctx.get("last_wo_titles", [])),
+                "doc_chunk_ids": doc_chunk_ids,
+            },
+        }
+        prod.send("canonical.recommendation.created", out)
+        prod.flush()
+
+        run_id = out["event_id"]
+        write_run_summary(getattr(settings, "run_summary_dir", "outputs"), run_id, {
+            "run_id": run_id,
+            "status": "ok",
+            "recommendation_id": rec_id,
+            "event_id": evt.get("event_id"),
+            "model": model_meta,
+            "context_meta": out.get("context_meta", {}),
+        })
+
+        logger.info({"event":"rca.recommendation.created","id":rec_id,"model":model_meta,"ctx":out.get("context_meta")})
+PY
+
+# Health endpoint
+cat > maintenance_intelligence/api/health.py << 'PY'
+from fastapi import APIRouter
+from maintenance_intelligence.runner.config import Settings
+import socket
+
+router = APIRouter()
+
+@router.get("/healthz")
+def healthz():
+    # Basic process-level health; deeper checks can be added (Kafka/PG pings)
+    return {"status": "ok", "host": socket.gethostname()}
+PY
+
+# Mount health router in API (append import & include_router if not already present)
+if ! grep -q "healthz" maintenance_intelligence/api/main.py; then
+  sed -i '1i from maintenance_intelligence.api.health import router as health_router' maintenance_intelligence/api/main.py
+  sed -i 's/app = FastAPI.*/&\\napp.include_router(health_router)/' maintenance_intelligence/api/main.py
+fi
+
+# Test (basic)
+cat > tests/test_context_smoke.py << 'PY'
+from maintenance_intelligence.context.assembler import get_event_context
+def test_context_smoke():
+    evt = {"asset_id":"TEST-ASSET","kind":"alarm"}
+    ctx = get_event_context(evt)
+    assert "asset_id" in ctx
+PY
+
+# Commit & push
+git add .
+git commit -m "feat: context assembly (MVP) + RAG bootstrap stubs + /healthz"
+git push -u origin "$BRANCH"

--- a/refactor_genai.sh
+++ b/refactor_genai.sh
@@ -1,0 +1,199 @@
+set -euo pipefail
+BRANCH="feature/genai-gateway-run-summaries"
+
+# Create/checkout branch
+git fetch origin
+git checkout -b "$BRANCH" || git checkout "$BRANCH"
+
+# Ensure dirs
+mkdir -p maintenance_intelligence/genai maintenance_intelligence/runner tests
+
+# Add openai dependency to pyproject (idempotent best-effort)
+if ! grep -q '"openai' pyproject.toml; then
+  perl -0777 -pe 's/(dependencies = \[\n)/$1  "openai>=1.0",\n/s' -i pyproject.toml
+fi
+
+# Run summaries writer
+cat > maintenance_intelligence/runner/summaries.py << 'PY'
+import json, os, datetime as dt
+from pathlib import Path
+
+def write_run_summary(dir_path: str, run_id: str, payload: dict) -> str:
+    date_dir = Path(dir_path) / dt.datetime.utcnow().strftime("%Y-%m-%d")
+    date_dir.mkdir(parents=True, exist_ok=True)
+    out = date_dir / f"{run_id}.json"
+    with out.open("w") as f:
+        json.dump(payload, f, indent=2)
+    return str(out)
+PY
+
+# Append GenAI + run summary settings to Settings (idempotent guard)
+if ! grep -q "genai_model" maintenance_intelligence/runner/config.py; then
+cat >> maintenance_intelligence/runner/config.py << 'PY'
+
+# --- GenAI / summaries ---
+from pydantic import Field  # ensure imported
+
+setattr(Settings, "genai_model", Field(default="gpt-4.1"))
+setattr(Settings, "genai_timeout_s", Field(default=25))
+setattr(Settings, "run_summary_dir", Field(default="outputs"))
+PY
+fi
+
+# OpenAI gateway
+mkdir -p maintenance_intelligence/genai
+cat > maintenance_intelligence/genai/gateway.py << 'PY'
+import os, time
+from typing import Dict, Any
+from loguru import logger
+try:
+    from openai import OpenAI
+except Exception:
+    OpenAI = None
+
+class GenAIGateway:
+    def __init__(self, api_key: str, model: str, timeout_s: int = 25):
+        self.model = model
+        self.timeout_s = timeout_s
+        if OpenAI is None:
+            raise RuntimeError("openai package not installed")
+        self.client = OpenAI(api_key=api_key)
+
+    def call_rca(self, event: Dict[str, Any], context: Dict[str, Any]) -> Dict[str, Any]:
+        t0 = time.time()
+        prompt = self._build_prompt(event, context)
+        try:
+            resp = self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": "You are an industrial maintenance RCA assistant. Be concise and cite signals/WOs/docs when possible."},
+                    {"role": "user", "content": prompt},
+                ],
+                temperature=0.2,
+                timeout=self.timeout_s,
+            )
+            text = resp.choices[0].message.content.strip() if resp.choices else ""
+            usage = getattr(resp, "usage", None)
+            tokens = usage.total_tokens if usage else None
+        except Exception as e:
+            logger.error({"event":"genai.error","err":str(e)})
+            text, tokens = f"[GENAI_ERROR] {e}", None
+
+        latency = int((time.time() - t0) * 1000)
+        return {
+            "text": text,
+            "model_version": self.model,
+            "tokens": tokens,
+            "latency_ms": latency,
+        }
+
+    def _build_prompt(self, event: Dict[str, Any], context: Dict[str, Any]) -> str:
+        lines = []
+        lines.append("Task: Draft an RCA hypothesis and recommended next actions for this alarm/anomaly.")
+        lines.append(f"Event: {event}")
+        lines.append(f"Context: {context}")
+        lines.append("Output format:\\n- Title\\n- Hypothesis (2-4 bullets)\\n- Evidence to check (signals/WOs/docs)\\n- Immediate actions (1-3)\\n- Longer-term PM/design suggestions (1-2)")
+        return "\\n".join(lines)
+PY
+
+# Wire RCA agent to use gateway + run summaries
+cat > maintenance_intelligence/services/rca_agent.py << 'PY'
+import os, json, uuid, datetime as dt
+from kafka import KafkaConsumer, KafkaProducer
+from loguru import logger
+from maintenance_intelligence.runner.config import Settings
+from maintenance_intelligence.genai.gateway import GenAIGateway
+from maintenance_intelligence.runner.summaries import write_run_summary
+
+def rca_agent(kafka_bootstrap: str = None):
+    settings = Settings()
+    kafka_bootstrap = kafka_bootstrap or settings.kafka_bootstrap
+
+    cons = KafkaConsumer(
+        "canonical.event.raised",
+        bootstrap_servers=kafka_bootstrap,
+        value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+        group_id="agent-rca",
+        auto_offset_reset="earliest",
+    )
+    prod = KafkaProducer(bootstrap_servers=kafka_bootstrap,
+                         value_serializer=lambda v: json.dumps(v).encode("utf-8"))
+
+    openai_key = os.getenv("OPENAI_API_KEY")
+    if not openai_key:
+        logger.warning({"event":"genai.missing_key","note":"OPENAI_API_KEY not set; using fallback text"})
+        gateway = None
+    else:
+        gateway = GenAIGateway(api_key=openai_key, model=getattr(settings, "genai_model", "gpt-4.1"),
+                               timeout_s=getattr(settings, "genai_timeout_s", 25))
+
+    for msg in cons:
+        evt = msg.value
+        if evt.get("kind") not in ("alarm", "anomaly"):
+            continue
+
+        context = {"notes": "MVP context; extend with signals/WOs/docs"}
+
+        if gateway:
+            g = gateway.call_rca(evt, context)
+            rationale = g.get("text", "No output")
+            model_meta = {"name": "openai", "version": g.get("model_version"), "tokens": g.get("tokens"), "latency_ms": g.get("latency_ms")}
+        else:
+            rationale = "Stub RCA (no OPENAI_API_KEY). Replace with GenAI output once key is set."
+            model_meta = {"name": "openai", "version": "unset", "tokens": None, "latency_ms": None}
+
+        rec_id = str(uuid.uuid4())
+        out = {
+            "event_type": "recommendation.created",
+            "event_id": str(uuid.uuid4()),
+            "occurred_at": dt.datetime.utcnow().isoformat() + "Z",
+            "org_id": evt.get("org_id"),
+            "recommendation": {
+                "id": rec_id,
+                "asset_id": evt.get("asset_id"),
+                "title": f"Investigate {evt.get('kind')} on asset {evt.get('asset_id')}",
+                "rationale": rationale,
+                "evidence": [evt.get("event_id", "")],
+                "model": model_meta,
+                "immutable": True,
+            },
+            "lineage": {"source": "agent-rca-genai"},
+        }
+        prod.send("canonical.recommendation.created", out)
+        prod.flush()
+
+        run_id = out["event_id"]
+        write_run_summary(getattr(settings, "run_summary_dir", "outputs"), run_id, {
+            "run_id": run_id,
+            "status": "ok",
+            "recommendation_id": rec_id,
+            "event_id": evt.get("event_id"),
+            "model": model_meta,
+        })
+
+        logger.info({"event":"rca.recommendation.created","id":rec_id,"model":model_meta})
+PY
+
+# Smoke test (placeholder)
+cat > tests/test_rca_smoke.py << 'PY'
+def test_placeholder():
+    assert True
+PY
+
+# README update
+cat >> README.md << 'PY'
+
+## GenAI Gateway (OpenAI) & Run Summaries
+
+- Set OPENAI_API_KEY to enable GenAI RCA drafts.
+- Defaults:
+  - MI_GENAI_MODEL=gpt-4.1
+  - MI_GENAI_TIMEOUT_S=25
+  - MI_RUN_SUMMARY_DIR=outputs (JSON artifacts per run)
+- RCA agent includes model_version/tokens/latency in recommendation.model.
+PY
+
+# Commit & push
+git add .
+git commit -m "feat: OpenAI GenAI gateway integration for RCA + run summaries (JSON artifacts)"
+git push -u origin "$BRANCH"

--- a/refactor_migrations.sh
+++ b/refactor_migrations.sh
@@ -1,0 +1,165 @@
+set -euo pipefail
+BRANCH="feature/migrations-and-health"
+
+git fetch origin
+git checkout -b "$BRANCH" || git checkout "$BRANCH"
+
+# Folders
+mkdir -p maintenance_intelligence/db/migrations maintenance_intelligence/api
+
+# Minimal SQL-first migrations with idempotent guards
+cat > maintenance_intelligence/db/migrations/001_init.sql << 'SQL'
+-- events table
+CREATE TABLE IF NOT EXISTS events (
+  event_id TEXT PRIMARY KEY,
+  event_time TIMESTAMPTZ,
+  org_id TEXT,
+  asset_id TEXT,
+  kind TEXT,
+  severity TEXT,
+  summary TEXT,
+  details JSONB,
+  lineage JSONB
+);
+
+-- workorders table
+CREATE TABLE IF NOT EXISTS workorders (
+  wo_id TEXT PRIMARY KEY,
+  asset_id TEXT,
+  status TEXT,
+  title TEXT,
+  description TEXT,
+  priority TEXT,
+  metadata JSONB
+);
+
+-- optional doc_chunks stub for RAG
+CREATE TABLE IF NOT EXISTS doc_chunks (
+  chunk_id TEXT PRIMARY KEY,
+  asset_id TEXT,
+  title TEXT,
+  content TEXT,
+  source TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+SQL
+
+# Simple migration runner (applies SQL files once; stores applied filenames)
+cat > maintenance_intelligence/db/migrate.py << 'PY'
+import os, glob, psycopg2
+from loguru import logger
+from maintenance_intelligence.runner.config import Settings
+
+DDL_TRACK_TABLE = "mi_schema_migrations"
+
+def ensure_track_table(cur):
+    cur.execute(f"""
+        CREATE TABLE IF NOT EXISTS {DDL_TRACK_TABLE} (
+            filename TEXT PRIMARY KEY,
+            applied_at TIMESTAMPTZ DEFAULT now()
+        )
+    """)
+
+def already_applied(cur, fname: str) -> bool:
+    cur.execute(f"SELECT 1 FROM {DDL_TRACK_TABLE} WHERE filename = %s", (fname,))
+    return cur.fetchone() is not None
+
+def apply_sql(cur, sql_text: str):
+    cur.execute(sql_text)
+
+def run():
+    settings = Settings()
+    conn = psycopg2.connect(settings.pg_dsn)
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                ensure_track_table(cur)
+                files = sorted(glob.glob(os.path.join(os.path.dirname(__file__), "migrations", "*.sql")))
+                for f in files:
+                    name = os.path.basename(f)
+                    if already_applied(cur, name):
+                        logger.info({"event":"migration.skip","file":name})
+                        continue
+                    with open(f, "r") as fh:
+                        sql_text = fh.read()
+                    logger.info({"event":"migration.apply","file":name})
+                    apply_sql(cur, sql_text)
+                    cur.execute(f"INSERT INTO {DDL_TRACK_TABLE} (filename) VALUES (%s)", (name,))
+        logger.info({"event":"migration.done"})
+    finally:
+        conn.close()
+
+if __name__ == "__main__":
+    run()
+PY
+
+# Stronger health checks: Kafka + PG
+cat > maintenance_intelligence/api/health.py << 'PY'
+from fastapi import APIRouter, Query
+from maintenance_intelligence.runner.config import Settings
+import socket, psycopg2
+from kafka import KafkaAdminClient
+
+router = APIRouter()
+
+@router.get("/healthz")
+def healthz(deep: bool = Query(False, description="Enable deep checks (Kafka/PG)")):
+    info = {"status": "ok", "host": socket.gethostname()}
+    if not deep:
+        return info
+
+    settings = Settings()
+    # PG check
+    try:
+        conn = psycopg2.connect(settings.pg_dsn)
+        try:
+            with conn, conn.cursor() as cur:
+                cur.execute("SELECT 1")
+            info["pg"] = "ok"
+        finally:
+            conn.close()
+    except Exception as e:
+        info["pg"] = f"error: {e}"
+        info["status"] = "degraded"
+
+    # Kafka check
+    try:
+        admin = KafkaAdminClient(bootstrap_servers=settings.kafka_bootstrap, client_id="mi-health")
+        topics = admin.list_topics()
+        info["kafka"] = "ok" if topics is not None else "unknown"
+    except Exception as e:
+        info["kafka"] = f"error: {e}"
+        info["status"] = "degraded"
+
+    return info
+PY
+
+# Ensure health router is mounted
+if ! grep -q "health_router" maintenance_intelligence/api/main.py; then
+  sed -i '1i from maintenance_intelligence.api.health import router as health_router' maintenance_intelligence/api/main.py
+  sed -i 's/app = FastAPI.*/&\napp.include_router(health_router)/' maintenance_intelligence/api/main.py
+fi
+
+# README snippet
+cat >> README.md << 'PY'
+
+## Database Migrations & Health Checks
+
+- Run migrations:
+  - python -m maintenance_intelligence.db.migrate
+- Health endpoint:
+  - GET /healthz (basic)
+  - GET /healthz?deep=true (PG + Kafka checks)
+PY
+
+# Basic test: migration runner importable
+cat > tests/test_migrate_import.py << 'PY'
+def test_migrate_import():
+    import maintenance_intelligence.db.migrate as m
+    assert hasattr(m, "run")
+PY
+
+# Commit & push
+git add .
+git commit -m "feat: SQL-first migrations + deep health checks (/healthz?deep=true) + migration runner"
+git push -u origin "$BRANCH"

--- a/tests/test_context_smoke.py
+++ b/tests/test_context_smoke.py
@@ -1,0 +1,5 @@
+from maintenance_intelligence.context.assembler import get_event_context
+def test_context_smoke():
+    evt = {"asset_id":"TEST-ASSET","kind":"alarm"}
+    ctx = get_event_context(evt)
+    assert "asset_id" in ctx

--- a/tests/test_migrate_import.py
+++ b/tests/test_migrate_import.py
@@ -1,0 +1,3 @@
+def test_migrate_import():
+    import maintenance_intelligence.db.migrate as m
+    assert hasattr(m, "run")

--- a/tests/test_rca_smoke.py
+++ b/tests/test_rca_smoke.py
@@ -1,0 +1,2 @@
+def test_placeholder():
+    assert True


### PR DESCRIPTION
Adds lightweight SQL-first DB migrations with idempotent runner, stronger health checks for Kafka and PG, and updates README.

- maintenance_intelligence/db/migrations/001_init.sql: creates events, workorders, doc_chunks tables
- maintenance_intelligence/db/migrate.py: migration runner that tracks applied files
- Updated maintenance_intelligence/api/health.py: deep checks for PG and Kafka when ?deep=true
- tests/test_migrate_import.py: basic import test

Run migrations with: python -m maintenance_intelligence.db.migrate
Health checks: GET /healthz (basic) or /healthz?deep=true (with Kafka/PG pings)