### PR TITLE
feat(platform): add multi-tenant RBAC scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,10 @@ MI_GENAI_TIMEOUT_S=25
 # Outputs / Logs
 MI_RUN_SUMMARY_DIR=outputs
 MI_CRON_LOG_DIR=logs
+
+# Multi-tenant / Auth
+MI_MULTI_TENANT=false
+MI_DEFAULT_ORG=default-org
+MI_AUTH_MODE=none
+MI_API_KEYS={"demo-viewer":{"org_id":"default-org","role":"viewer"}}
+MI_KAFKA_TENANT_MODE=message

--- a/README.md
+++ b/README.md
@@ -151,3 +151,21 @@ Notes:
 - API / CSV include:
   - per_asset_acceptance: rate, accepts, total
   - per_asset_ttr: average TTR seconds by asset
+
+## Multi-Tenant and RBAC
+
+- `MI_MULTI_TENANT=true` enables org-aware query scoping for outcomes, feedback, bad-actors, context assembly, and RAG document retrieval.
+- `MI_AUTH_MODE=none|api_key` controls request auth. In `api_key` mode, send `X-API-Key` and configure `MI_API_KEYS` as JSON: `{"key-1":{"org_id":"org-a","role":"viewer"}}`.
+- Roles:
+  - `viewer`: read scoped reports and signals
+  - `operator`: viewer permissions plus RCA trigger and feedback submission
+  - `admin`: full access in the current stub
+- Kafka topic strategy:
+  - `MI_KAFKA_TENANT_MODE=message`: keep shared topics and filter by `org_id` in the consumer
+  - `MI_KAFKA_TENANT_MODE=namespaced`: publish and consume `canonical.{org_id}.*` topics for single-org worker deployments
+- Single-tenant deployment:
+  - leave `MI_MULTI_TENANT=false` and `MI_AUTH_MODE=none`
+- Multi-tenant deployment:
+  - enable `MI_MULTI_TENANT=true`
+  - provision per-org API keys via `MI_API_KEYS`
+  - run workers with the org selected by `MI_DEFAULT_ORG` when using namespaced Kafka topics

--- a/maintenance_intelligence/api/auth.py
+++ b/maintenance_intelligence/api/auth.py
@@ -1,0 +1,44 @@
+from typing import Callable
+
+from fastapi import Depends, Header, HTTPException
+
+from maintenance_intelligence.multitenancy import TenantContext, normalize_role, resolve_org_id, role_allows
+from maintenance_intelligence.runner.config import Settings
+
+
+def _context_from_api_key(api_key: str, settings: Settings) -> TenantContext:
+    payload = settings.api_keys.get(api_key)
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=403, detail="Invalid API key")
+    org_id = payload.get("org_id")
+    role = payload.get("role")
+    if not org_id or not role:
+        raise HTTPException(status_code=500, detail="API key configuration incomplete")
+    try:
+        role = normalize_role(role)
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return TenantContext(org_id=str(org_id), role=role, subject="api_key")
+
+
+def get_request_context(x_api_key: str | None = Header(default=None, alias="X-API-Key")) -> TenantContext:
+    settings = Settings()
+    auth_mode = (settings.auth_mode or "none").strip().lower()
+    if auth_mode == "none":
+        return TenantContext(org_id=resolve_org_id(settings), role="admin", subject="anonymous")
+    if auth_mode != "api_key":
+        raise HTTPException(status_code=500, detail="Unsupported auth mode")
+    if not x_api_key:
+        raise HTTPException(status_code=401, detail="Missing API key")
+    return _context_from_api_key(x_api_key, settings)
+
+
+def require_role(minimum_role: str) -> Callable:
+    minimum_role = normalize_role(minimum_role)
+
+    def dependency(access: TenantContext = Depends(get_request_context)) -> TenantContext:
+        if not role_allows(access.role, minimum_role):
+            raise HTTPException(status_code=403, detail="Insufficient role")
+        return access
+
+    return dependency

--- a/maintenance_intelligence/api/feedback.py
+++ b/maintenance_intelligence/api/feedback.py
@@ -1,10 +1,14 @@
-from fastapi import APIRouter, HTTPException
+import json
+import uuid
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-from typing import Optional, Dict, Any
-import uuid, psycopg2
 from maintenance_intelligence.runner.config import Settings
+from maintenance_intelligence.api.auth import require_role
 from maintenance_intelligence.context.assembler import with_pg
 from maintenance_intelligence.api.metrics import REGISTRY
+from maintenance_intelligence.multitenancy import TenantContext
 from prometheus_client import Counter
 
 router = APIRouter(prefix="/api/v1/rca", tags=["rca"])
@@ -17,9 +21,10 @@ class FeedbackPayload(BaseModel):
     changes: Optional[Dict[str, Any]] = None
     reason: Optional[str] = None
     user_id: Optional[str] = None
+    asset_id: Optional[str] = None
 
 @router.post("/feedback")
-def submit_feedback(p: FeedbackPayload):
+def submit_feedback(p: FeedbackPayload, access: TenantContext = Depends(require_role("operator"))):
     if p.action not in ("accept","reject","edited"):
         raise HTTPException(status_code=400, detail="Invalid action")
     s = Settings()
@@ -32,7 +37,7 @@ def submit_feedback(p: FeedbackPayload):
                 INSERT INTO rca_feedback(id, run_id, recommendation_id, org_id, asset_id, action, changes, reason, user_id)
                 VALUES (%s,%s,%s,%s,%s,%s,%s::jsonb,%s,%s)
                 """,
-                (fid, p.run_id, p.recommendation_id, None, None, p.action, (p.changes and __import__("json").dumps(p.changes)) or None, p.reason, p.user_id)
+                (fid, p.run_id, p.recommendation_id, access.org_id, p.asset_id, p.action, json.dumps(p.changes) if p.changes else None, p.reason, p.user_id)
             )
         try:
             feedback_total.labels(action=p.action).inc()

--- a/maintenance_intelligence/api/main.py
+++ b/maintenance_intelligence/api/main.py
@@ -1,3 +1,7 @@
+from fastapi import Depends, FastAPI
+from pydantic import BaseModel
+
+from maintenance_intelligence.api.auth import require_role
 from maintenance_intelligence.api.reports import router as reports_router
 from maintenance_intelligence.api.health import router as health_router
 from maintenance_intelligence.api.signals import router as signals_router
@@ -5,11 +9,10 @@ from maintenance_intelligence.api.metrics import router as metrics_router
 from maintenance_intelligence.api.feedback import router as feedback_router
 from maintenance_intelligence.api.outcomes import router as outcomes_router
 from maintenance_intelligence.api.otel import init_tracing
-from fastapi import FastAPI
-from pydantic import BaseModel
 from maintenance_intelligence.runner.core import run
 from maintenance_intelligence.runner.config import Settings
 from maintenance_intelligence.runner.logging import setup_logger
+from maintenance_intelligence.multitenancy import TenantContext
 
 app = FastAPI(title="Maintenance Intelligence API", version="0.1.0")
 app.include_router(health_router)
@@ -26,5 +29,5 @@ class TriggerPayload(BaseModel):
     event_id: str
 
 @app.post("/api/v1/agents/rca/trigger")
-def trigger_rca(p: TriggerPayload):
-    return run(p.event_id, settings)
+def trigger_rca(p: TriggerPayload, access: TenantContext = Depends(require_role("operator"))):
+    return run(p.event_id, Settings(), org_id=access.org_id)

--- a/maintenance_intelligence/api/outcomes.py
+++ b/maintenance_intelligence/api/outcomes.py
@@ -4,8 +4,10 @@ import io
 from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 import psycopg2
+from maintenance_intelligence.api.auth import require_role
+from maintenance_intelligence.multitenancy import TenantContext, org_scope_enabled
 from maintenance_intelligence.runner.config import Settings
 
 router = APIRouter(prefix="/api/v1/reports", tags=["reports"])
@@ -23,6 +25,12 @@ def with_pg(dsn: str):
 
 def _window_clause(days: int) -> str:
     return f"(NOW() - INTERVAL '{int(days)} days')"
+
+
+def _org_scope_sql(settings: Settings, org_id: str, column: str = "org_id") -> tuple[str, tuple[Any, ...]]:
+    if not org_scope_enabled(settings):
+        return "", ()
+    return f" AND {column} = %s", (org_id,)
 
 
 def _parse_timestamp(value: Any) -> Optional[dt.datetime]:
@@ -129,15 +137,17 @@ def _build_ttr_measurements(
     return measurements
 
 
-def _fetch_workorders_for_ttr(cur, window: int) -> List[Dict[str, Any]]:
+def _fetch_workorders_for_ttr(cur, window: int, settings: Settings, org_id: str) -> List[Dict[str, Any]]:
+    org_sql, org_params = _org_scope_sql(settings, org_id)
     cur.execute(
         f"""
             SELECT wo_id, asset_id, metadata
             FROM workorders
-            WHERE COALESCE((metadata->>'created_at')::timestamptz, NOW()) > {_window_clause(window)}
+            WHERE COALESCE((metadata->>'created_at')::timestamptz, NOW()) > {_window_clause(window)}{org_sql}
             ORDER BY COALESCE((metadata->>'created_at')::timestamptz, NOW()) DESC
             LIMIT 500
-        """
+        """,
+        org_params,
     )
     return [
         {"wo_id": row[0], "asset_id": row[1], "metadata": row[2] or {}}
@@ -145,7 +155,13 @@ def _fetch_workorders_for_ttr(cur, window: int) -> List[Dict[str, Any]]:
     ]
 
 
-def _fetch_candidate_events(cur, workorders: List[Dict[str, Any]], fallback_window_h: int) -> List[Dict[str, Any]]:
+def _fetch_candidate_events(
+    cur,
+    workorders: List[Dict[str, Any]],
+    fallback_window_h: int,
+    settings: Settings,
+    org_id: str,
+) -> List[Dict[str, Any]]:
     evidence_event_ids = []
     asset_ids = set()
     workorder_timestamps = []
@@ -176,6 +192,11 @@ def _fetch_candidate_events(cur, workorders: List[Dict[str, Any]], fallback_wind
         where_clauses.append("(asset_id = ANY(%s) AND occurred_at BETWEEN %s AND %s)")
         params.extend([sorted(asset_ids), min_ts, max_ts])
 
+    if org_scope_enabled(settings):
+        where_clauses = [f"({clause})" for clause in where_clauses]
+        where_clauses.append("org_id = %s")
+        params.append(org_id)
+
     cur.execute(
         f"""
             SELECT event_id, asset_id, occurred_at
@@ -189,8 +210,7 @@ def _fetch_candidate_events(cur, workorders: List[Dict[str, Any]], fallback_wind
         for row in (cur.fetchall() or [])
     ]
 
-@router.get("/rca-outcomes")
-def rca_outcomes(window: int = Query(30, ge=1, le=365)) -> Dict[str, Any]:
+def _rca_outcomes_report(window: int, access: TenantContext) -> Dict[str, Any]:
     if window > 365:
         raise HTTPException(status_code=400, detail="Window cannot exceed 365 days")
     s = Settings()
@@ -202,31 +222,35 @@ def rca_outcomes(window: int = Query(30, ge=1, le=365)) -> Dict[str, Any]:
         out: Dict[str, Any] = {}
         fallback_window_h = max(1, int(getattr(s, "ttr_fallback_window_h", 24) or 24))
         with conn, conn.cursor() as cur:
+            fb_scope_sql, fb_scope_params = _org_scope_sql(s, access.org_id)
             # Feedback counts by action (accept/reject/edited)
             cur.execute(f"""
                 SELECT action, COUNT(*) FROM rca_feedback
                 WHERE created_at > {_window_clause(window)}
+                {fb_scope_sql}
                 GROUP BY action
-            """)
+            """, fb_scope_params)
             fb = {r[0]: int(r[1]) for r in cur.fetchall() if r and r[0]}
             total = sum(fb.values())
             accept = fb.get("accept", 0)
             out["feedback_counts"] = fb
             out["acceptance_rate"] = (accept / total) if total > 0 else None
 
+            wo_scope_sql, wo_scope_params = _org_scope_sql(s, access.org_id, column="w.org_id")
             cur.execute(f"""
                 SELECT w.asset_id, COUNT(*) AS n
                 FROM workorders w
                 WHERE COALESCE((w.metadata->>'created_at')::timestamptz, NOW()) > {_window_clause(window)}
+                {wo_scope_sql}
                 GROUP BY w.asset_id
                 ORDER BY n DESC
                 LIMIT 10
-            """)
+            """, wo_scope_params)
             out["top_assets_by_wo_volume"] = [{"asset_id": r[0], "count": int(r[1])} for r in cur.fetchall() if r]
 
             try:
-                workorders = _fetch_workorders_for_ttr(cur, window)
-                candidate_events = _fetch_candidate_events(cur, workorders, fallback_window_h)
+                workorders = _fetch_workorders_for_ttr(cur, window, s, access.org_id)
+                candidate_events = _fetch_candidate_events(cur, workorders, fallback_window_h, s, access.org_id)
                 ttr_rows = _build_ttr_measurements(workorders, candidate_events, fallback_window_h)
             except Exception:
                 ttr_rows = []
@@ -236,14 +260,16 @@ def rca_outcomes(window: int = Query(30, ge=1, le=365)) -> Dict[str, Any]:
 
         try:
             with conn, conn.cursor() as cur2:
+                fb_scope_sql, fb_scope_params = _org_scope_sql(s, access.org_id)
                 cur2.execute(f"""
                     SELECT asset_id,
                            COUNT(*) FILTER (WHERE action = 'accept') AS accept_cnt,
                            COUNT(*) AS total_cnt
                     FROM rca_feedback
                     WHERE created_at > {_window_clause(window)}
+                    {fb_scope_sql}
                     GROUP BY asset_id
-                """)
+                """, fb_scope_params)
                 rows = cur2.fetchall() or []
                 out["per_asset_acceptance"] = [
                     {
@@ -281,10 +307,21 @@ def rca_outcomes(window: int = Query(30, ge=1, le=365)) -> Dict[str, Any]:
     finally:
         conn.close()
 
+
+@router.get("/rca-outcomes")
+def rca_outcomes(
+    window: int = Query(30, ge=1, le=365),
+    access: TenantContext = Depends(require_role("viewer")),
+) -> Dict[str, Any]:
+    return _rca_outcomes_report(window, access)
+
 @router.get("/rca-outcomes/csv")
-def rca_outcomes_csv(window: int = Query(30, ge=1, le=365)):
+def rca_outcomes_csv(
+    window: int = Query(30, ge=1, le=365),
+    access: TenantContext = Depends(require_role("viewer")),
+):
     # Flatten a report view for leadership export
-    rep = rca_outcomes(window=window)  # reuse computation
+    rep = _rca_outcomes_report(window=window, access=access)
     rows = []
     # Feedback counts by action -> key/value rows
     for k, v in (rep.get("feedback_counts") or {}).items():

--- a/maintenance_intelligence/api/reports.py
+++ b/maintenance_intelligence/api/reports.py
@@ -1,6 +1,9 @@
-from fastapi import APIRouter, Query
-from typing import List, Dict, Any
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, Query
 import psycopg2
+from maintenance_intelligence.api.auth import require_role
+from maintenance_intelligence.multitenancy import TenantContext, org_scope_enabled
 from maintenance_intelligence.runner.config import Settings
 
 router = APIRouter(prefix="/api/v1/reports", tags=["reports"])
@@ -14,7 +17,10 @@ def with_pg(dsn: str):
             time.sleep(1)
 
 @router.get("/bad-actors")
-def bad_actors(limit: int = Query(20, ge=1, le=200)) -> List[Dict[str, Any]]:
+def bad_actors(
+    limit: int = Query(20, ge=1, le=200),
+    access: TenantContext = Depends(require_role("viewer")),
+) -> List[Dict[str, Any]]:
     """
     Ranks assets by recent event/WO activity (MVP heuristic):
     - score = (#events last 90d) + 2*(#workorders last 90d)
@@ -24,13 +30,16 @@ def bad_actors(limit: int = Query(20, ge=1, le=200)) -> List[Dict[str, Any]]:
     conn = with_pg(s.pg_dsn)
     try:
         with conn, conn.cursor() as cur:
+            org_clause = " AND org_id = %s" if org_scope_enabled(s) else ""
+            org_params = (access.org_id,) if org_scope_enabled(s) else ()
             # events count (90d)
             cur.execute("""
                 SELECT asset_id, COUNT(*) AS ev_count, MAX(occurred_at) AS last_evt_at
                 FROM events
                 WHERE occurred_at > (NOW() - INTERVAL '90 days')
+            """ + org_clause + """
                 GROUP BY asset_id
-            """)
+            """, org_params)
             ev = {r[0]: {"ev_count": r[1], "last_evt_at": r[2]} for r in cur.fetchall() if r and r[0]}
 
             # latest severity per asset
@@ -38,8 +47,9 @@ def bad_actors(limit: int = Query(20, ge=1, le=200)) -> List[Dict[str, Any]]:
                 SELECT DISTINCT ON (asset_id) asset_id, severity, occurred_at
                 FROM events
                 WHERE occurred_at > (NOW() - INTERVAL '90 days')
+            """ + org_clause + """
                 ORDER BY asset_id, occurred_at DESC
-            """)
+            """, org_params)
             sev = {r[0]: r[1] for r in cur.fetchall() if r and r[0]}
 
             # workorder count (90d)
@@ -47,8 +57,9 @@ def bad_actors(limit: int = Query(20, ge=1, le=200)) -> List[Dict[str, Any]]:
                 SELECT asset_id, COUNT(*) AS wo_count
                 FROM workorders
                 WHERE COALESCE((metadata->>'created_at')::timestamptz, NOW()) > (NOW() - INTERVAL '90 days')
+            """ + (" AND org_id = %s" if org_scope_enabled(s) else "") + """
                 GROUP BY asset_id
-            """)
+            """, org_params)
             wo = {r[0]: r[1] for r in cur.fetchall() if r and r[0]}
 
         rows = []

--- a/maintenance_intelligence/api/signals.py
+++ b/maintenance_intelligence/api/signals.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import List, Optional
 import psycopg2
+from maintenance_intelligence.api.auth import require_role
+from maintenance_intelligence.multitenancy import TenantContext
 from maintenance_intelligence.runner.config import Settings
 from maintenance_intelligence.context.assembler import with_pg
 
@@ -9,7 +11,8 @@ router = APIRouter()
 @router.get("/api/v1/signals/summary")
 async def get_signals_summary(
     asset_id: str = Query(..., description="Asset ID to get signals for"),
-    limit: int = Query(10, description="Max number of signals to return")
+    limit: int = Query(10, description="Max number of signals to return"),
+    access: TenantContext = Depends(require_role("viewer")),
 ):
     """Get recent signals and rollups for an asset."""
     settings = Settings()

--- a/maintenance_intelligence/context/assembler.py
+++ b/maintenance_intelligence/context/assembler.py
@@ -2,6 +2,7 @@ import datetime as dt
 from typing import Dict, Any, List, Optional
 import psycopg2
 from loguru import logger
+from maintenance_intelligence.multitenancy import org_scope_enabled, resolve_org_id
 from maintenance_intelligence.runner.config import Settings
 
 def with_pg(dsn: str):
@@ -15,7 +16,7 @@ def with_pg(dsn: str):
             time.sleep(0.2)
     raise last_error
 
-def get_event_context(event: Dict[str, Any], settings: Optional[Settings] = None) -> Dict[str, Any]:
+def get_event_context(event: Dict[str, Any], settings: Optional[Settings] = None, org_id: Optional[str] = None) -> Dict[str, Any]:
     """
     MVP bootstrap context assembly.
     - last_wo_titles: last few WOs for the asset (90d)
@@ -25,6 +26,7 @@ def get_event_context(event: Dict[str, Any], settings: Optional[Settings] = None
     """
     settings = settings or Settings()
     asset_id = event.get("asset_id")
+    effective_org_id = resolve_org_id(settings, org_id or event.get("org_id"))
     out: Dict[str, Any] = {"asset_id": asset_id, "last_wo_titles": [], "signal_summary": {}, "doc_chunks": []}
     conn = None
     try:
@@ -36,8 +38,9 @@ def get_event_context(event: Dict[str, Any], settings: Optional[Settings] = None
                     """
                     SELECT title FROM workorders
                     WHERE asset_id = %s AND (NOW() - INTERVAL '90 days') < NOW()
+                    AND (%s = FALSE OR org_id = %s)
                     ORDER BY RANDOM() LIMIT 5
-                    """, (asset_id,)
+                    """, (asset_id, org_scope_enabled(settings), effective_org_id)
                 )
                 rows = cur.fetchall()
                 out["last_wo_titles"] = [r[0] for r in rows if r and r[0]]
@@ -100,7 +103,7 @@ def get_event_context(event: Dict[str, Any], settings: Optional[Settings] = None
             query = f"{event_kind} {event_summary} {' '.join(str(v) for v in event_details.values())}"
 
             retriever = HybridRetriever(settings.pg_dsn)
-            chunks = retriever.retrieve(query, asset_id, limit=5, token_budget=2000)
+            chunks = retriever.retrieve(query, asset_id, limit=5, token_budget=2000, org_id=effective_org_id)
             out["doc_chunks"] = [{"chunk_id": c["chunk_id"], "title": c["title"]} for c in chunks]
         except Exception as e:
             logger.debug({"event":"ctx.hybrid_rag.skip","err":str(e)})
@@ -111,9 +114,10 @@ def get_event_context(event: Dict[str, Any], settings: Optional[Settings] = None
                         """
                         SELECT chunk_id, title FROM doc_chunks
                         WHERE asset_id = %s
+                        AND (%s = FALSE OR org_id = %s)
                         ORDER BY RANDOM()
                         LIMIT 3
-                        """, (asset_id,)
+                        """, (asset_id, org_scope_enabled(settings), effective_org_id)
                     )
                     rows = cur.fetchall()
                     out["doc_chunks"] = [{"chunk_id": r[0], "title": r[1]} for r in rows if r]

--- a/maintenance_intelligence/db/alembic/versions/002_multi_tenant_rbac.py
+++ b/maintenance_intelligence/db/alembic/versions/002_multi_tenant_rbac.py
@@ -1,0 +1,31 @@
+"""Add org_id columns for multi-tenant workorders and doc chunks
+
+Revision ID: 002_multi_tenant_rbac
+Revises: 001_initial
+Create Date: 2026-03-14 11:45:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "002_multi_tenant_rbac"
+down_revision: Union[str, None] = "001_initial"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("workorders", sa.Column("org_id", sa.Text(), nullable=True))
+    op.add_column("doc_chunks", sa.Column("org_id", sa.Text(), nullable=True))
+    op.create_index("idx_workorders_org_asset", "workorders", ["org_id", "asset_id"], unique=False)
+    op.create_index("idx_doc_chunks_org_asset", "doc_chunks", ["org_id", "asset_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("idx_doc_chunks_org_asset", table_name="doc_chunks")
+    op.drop_index("idx_workorders_org_asset", table_name="workorders")
+    op.drop_column("doc_chunks", "org_id")
+    op.drop_column("workorders", "org_id")

--- a/maintenance_intelligence/db/migrations/005_multi_tenant.sql
+++ b/maintenance_intelligence/db/migrations/005_multi_tenant.sql
@@ -1,0 +1,5 @@
+ALTER TABLE workorders ADD COLUMN IF NOT EXISTS org_id TEXT;
+ALTER TABLE doc_chunks ADD COLUMN IF NOT EXISTS org_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_workorders_org_asset ON workorders (org_id, asset_id);
+CREATE INDEX IF NOT EXISTS idx_doc_chunks_org_asset ON doc_chunks (org_id, asset_id);

--- a/maintenance_intelligence/multitenancy.py
+++ b/maintenance_intelligence/multitenancy.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+
+ROLE_ORDER = {"viewer": 0, "operator": 1, "admin": 2}
+
+
+@dataclass(frozen=True)
+class TenantContext:
+    org_id: str
+    role: str
+    subject: str = "anonymous"
+
+
+def normalize_role(role: str) -> str:
+    role = (role or "viewer").strip().lower()
+    if role not in ROLE_ORDER:
+        raise ValueError(f"Unsupported role: {role}")
+    return role
+
+
+def role_allows(role: str, minimum_role: str) -> bool:
+    return ROLE_ORDER[normalize_role(role)] >= ROLE_ORDER[normalize_role(minimum_role)]
+
+
+def resolve_org_id(settings, org_id: Optional[str] = None) -> str:
+    return org_id or getattr(settings, "default_org", "default-org")
+
+
+def org_scope_enabled(settings) -> bool:
+    return bool(getattr(settings, "multi_tenant", False))
+
+
+def scoped_topic(base_topic: str, settings, org_id: Optional[str] = None) -> str:
+    if not org_scope_enabled(settings) or getattr(settings, "kafka_tenant_mode", "message") != "namespaced":
+        return base_topic
+    parts = base_topic.split(".")
+    if len(parts) < 2:
+        return base_topic
+    effective_org = resolve_org_id(settings, org_id)
+    return ".".join([parts[0], effective_org, *parts[1:]])
+
+
+def consumer_topics(base_topics: Iterable[str], settings, org_id: Optional[str] = None) -> list[str]:
+    return [scoped_topic(topic, settings, org_id=org_id) for topic in base_topics]
+
+
+def event_in_scope(message_org_id: Optional[str], settings, org_id: Optional[str] = None) -> bool:
+    if not org_scope_enabled(settings):
+        return True
+    return (message_org_id or resolve_org_id(settings)) == resolve_org_id(settings, org_id)

--- a/maintenance_intelligence/rag/ingest.py
+++ b/maintenance_intelligence/rag/ingest.py
@@ -68,18 +68,18 @@ def load_texts(path: str) -> List[Dict[str, Any]]:
             logger.warning({"event":"rag.read.skip","file":str(f),"err":str(e)})
     return docs
 
-def upsert_chunks(conn, asset_id: str, docs: List[Dict[str, Any]], embeddings: List[List[float]], titles: List[str]):
+def upsert_chunks(conn, asset_id: str, org_id: str, docs: List[Dict[str, Any]], embeddings: List[List[float]], titles: List[str]):
     with conn:
         with conn.cursor() as cur:
             for i, doc in enumerate(docs):
                 chunk_id = "DC-" + uuid.uuid4().hex[:12]
                 cur.execute(
                     """
-                    INSERT INTO doc_chunks (chunk_id, asset_id, title, content, source, embedding)
-                    VALUES (%s,%s,%s,%s,%s,%s)
+                    INSERT INTO doc_chunks (chunk_id, org_id, asset_id, title, content, source, embedding)
+                    VALUES (%s,%s,%s,%s,%s,%s,%s)
                     ON CONFLICT (chunk_id) DO NOTHING
                     """,
-                    (chunk_id, asset_id, titles[i], doc["content"], doc["source"], embeddings[i]),
+                    (chunk_id, org_id, asset_id, titles[i], doc["content"], doc["source"], embeddings[i]),
                 )
 
 def ingest_path(path: str, asset_id: str, chunk_size: int = 1200, bulk_mode: bool = False):
@@ -122,7 +122,7 @@ def ingest_path(path: str, asset_id: str, chunk_size: int = 1200, bulk_mode: boo
 
         texts = [c["content"] for c in all_chunks]
         embs = embed_texts(api_key, texts)
-        upsert_chunks(conn, asset_id, all_chunks, embs, all_titles)
+        upsert_chunks(conn, asset_id, s.default_org, all_chunks, embs, all_titles)
         logger.info({"event":"rag.ingested","chunks":len(all_chunks),"asset_id":asset_id,"bulk_mode":bulk_mode})
     finally:
         conn.close()

--- a/maintenance_intelligence/rag/retrieval.py
+++ b/maintenance_intelligence/rag/retrieval.py
@@ -15,16 +15,16 @@ class HybridRetriever:
         self.bm25_weight = bm25_weight
 
     def retrieve(self, query: str, asset_id: Optional[str] = None, limit: int = 10,
-                 token_budget: int = 4000) -> List[Dict[str, Any]]:
+                 token_budget: int = 4000, org_id: Optional[str] = None) -> List[Dict[str, Any]]:
         """
         Retrieve relevant chunks using hybrid BM25 + vector search.
         Returns top chunks within token budget.
         """
         # Get vector results
-        vector_results = self._vector_search(query, asset_id, limit * 2)
+        vector_results = self._vector_search(query, asset_id, limit * 2, org_id=org_id)
 
         # Get BM25 results
-        bm25_results = self._bm25_search(query, asset_id, limit * 2)
+        bm25_results = self._bm25_search(query, asset_id, limit * 2, org_id=org_id)
 
         # Combine scores
         combined = self._combine_scores(vector_results, bm25_results)
@@ -33,7 +33,7 @@ class HybridRetriever:
         combined.sort(key=lambda x: x['score'], reverse=True)
         return self._apply_token_budget(combined, token_budget)
 
-    def _vector_search(self, query: str, asset_id: Optional[str], limit: int) -> List[Dict[str, Any]]:
+    def _vector_search(self, query: str, asset_id: Optional[str], limit: int, org_id: Optional[str] = None) -> List[Dict[str, Any]]:
         """Vector similarity search using pgvector."""
         try:
             from maintenance_intelligence.genai.gateway import GenAIGateway
@@ -47,18 +47,18 @@ class HybridRetriever:
                     cur.execute("""
                         SELECT chunk_id, title, content, embedding <=> %s::vector as distance
                         FROM doc_chunks
-                        WHERE asset_id = %s AND embedding IS NOT NULL
+                        WHERE asset_id = %s AND (%s IS NULL OR org_id = %s) AND embedding IS NOT NULL
                         ORDER BY embedding <=> %s::vector
                         LIMIT %s
-                    """, (embedding, asset_id, embedding, limit))
+                    """, (embedding, asset_id, org_id, org_id, embedding, limit))
                 else:
                     cur.execute("""
                         SELECT chunk_id, title, content, embedding <=> %s::vector as distance
                         FROM doc_chunks
-                        WHERE embedding IS NOT NULL
+                        WHERE (%s IS NULL OR org_id = %s) AND embedding IS NOT NULL
                         ORDER BY embedding <=> %s::vector
                         LIMIT %s
-                    """, (embedding, embedding, limit))
+                    """, (embedding, org_id, org_id, embedding, limit))
 
                 results = cur.fetchall()
                 return [{
@@ -71,7 +71,7 @@ class HybridRetriever:
             # Fallback to BM25 only if vector search fails
             return []
 
-    def _bm25_search(self, query: str, asset_id: Optional[str], limit: int) -> List[Dict[str, Any]]:
+    def _bm25_search(self, query: str, asset_id: Optional[str], limit: int, org_id: Optional[str] = None) -> List[Dict[str, Any]]:
         """BM25 text search."""
         # Tokenize query
         query_terms = self._tokenize(query)
@@ -80,9 +80,12 @@ class HybridRetriever:
         with conn, conn.cursor() as cur:
             # Get all documents
             if asset_id:
-                cur.execute("SELECT chunk_id, title, content FROM doc_chunks WHERE asset_id = %s", (asset_id,))
+                cur.execute(
+                    "SELECT chunk_id, title, content FROM doc_chunks WHERE asset_id = %s AND (%s IS NULL OR org_id = %s)",
+                    (asset_id, org_id, org_id),
+                )
             else:
-                cur.execute("SELECT chunk_id, title, content FROM doc_chunks")
+                cur.execute("SELECT chunk_id, title, content FROM doc_chunks WHERE (%s IS NULL OR org_id = %s)", (org_id, org_id))
 
             docs = cur.fetchall()
 

--- a/maintenance_intelligence/runner/config.py
+++ b/maintenance_intelligence/runner/config.py
@@ -1,5 +1,9 @@
-from pydantic_settings import BaseSettings
+import json
+from typing import Any, Dict
+
 from pydantic import Field
+from pydantic_settings import BaseSettings
+
 
 class Settings(BaseSettings):
     env: str = Field(default="dev")
@@ -10,18 +14,32 @@ class Settings(BaseSettings):
     pg_password: str = Field(default="postgres", alias="POSTGRES_PASSWORD")
     pg_host: str = Field(default="timescaledb", alias="POSTGRES_HOST")
     ttr_fallback_window_h: int = Field(default=24)
+    multi_tenant: bool = Field(default=False, alias="MI_MULTI_TENANT")
+    default_org: str = Field(default="default-org", alias="MI_DEFAULT_ORG")
+    auth_mode: str = Field(default="none", alias="MI_AUTH_MODE")
+    api_keys_raw: str = Field(default="{}", alias="MI_API_KEYS")
+    kafka_tenant_mode: str = Field(default="message", alias="MI_KAFKA_TENANT_MODE")
+    genai_model: str = Field(default="gpt-4.1")
+    genai_timeout_s: int = Field(default=25)
+    run_summary_dir: str = Field(default="outputs")
+    openai_api_key: str | None = Field(default=None, alias="OPENAI_API_KEY")
 
     @property
     def pg_dsn(self) -> str:
         return f"dbname={self.pg_db} user={self.pg_user} password={self.pg_password} host={self.pg_host} port=5432"
 
+    @property
+    def database_url(self) -> str:
+        return self.pg_dsn
+
+    @property
+    def api_keys(self) -> Dict[str, Dict[str, Any]]:
+        try:
+            data = json.loads(self.api_keys_raw or "{}")
+        except json.JSONDecodeError:
+            return {}
+        return data if isinstance(data, dict) else {}
+
     class Config:
         env_prefix = "MI_"
         extra = "allow"
-
-# --- GenAI / summaries ---
-from pydantic import Field  # ensure imported
-
-setattr(Settings, "genai_model", Field(default="gpt-4.1"))
-setattr(Settings, "genai_timeout_s", Field(default=25))
-setattr(Settings, "run_summary_dir", Field(default="outputs"))

--- a/maintenance_intelligence/runner/core.py
+++ b/maintenance_intelligence/runner/core.py
@@ -3,10 +3,10 @@ from .logging import setup_logger, run_id, timed
 from loguru import logger
 
 @timed
-def run(event_id: str, settings: Settings):
+def run(event_id: str, settings: Settings, org_id: str | None = None):
     setup_logger(settings.log_level)
     rid = run_id()
-    logger.bind(run_id=rid).info({"event":"runner.start","event_id":event_id})
+    logger.bind(run_id=rid).info({"event":"runner.start","event_id":event_id, "org_id": org_id})
     rec_id = f"rec-{rid[:8]}"
     logger.info({"event":"recommendation.stub","id":rec_id,"note":"Kafka pipeline handles real flow"})
-    return {"run_id": rid, "status": "ok", "recommendation_id": rec_id}
+    return {"run_id": rid, "status": "ok", "recommendation_id": rec_id, "org_id": org_id}

--- a/maintenance_intelligence/services/ingestion.py
+++ b/maintenance_intelligence/services/ingestion.py
@@ -5,6 +5,8 @@ import psycopg2
 from loguru import logger
 import backoff
 from maintenance_intelligence.api.metrics import events_ingested_total
+from maintenance_intelligence.multitenancy import consumer_topics, event_in_scope
+from maintenance_intelligence.runner.config import Settings
 
 @backoff.on_exception(backoff.expo, psycopg2.Error, max_tries=5, max_time=60)
 def create_db_connection(dsn: str):
@@ -12,11 +14,10 @@ def create_db_connection(dsn: str):
     return psycopg2.connect(dsn)
 
 @backoff.on_exception(backoff.expo, KafkaError, max_tries=5, max_time=60)
-def create_kafka_consumer(kafka_bootstrap: str):
+def create_kafka_consumer(kafka_bootstrap: str, settings: Settings):
     """Create Kafka consumer with retry logic."""
     return KafkaConsumer(
-        "canonical.asset.upserted",
-        "canonical.event.raised",
+        *consumer_topics(["canonical.asset.upserted", "canonical.event.raised"], settings, org_id=settings.default_org),
         bootstrap_servers=kafka_bootstrap,
         value_deserializer=lambda v: json.loads(v.decode("utf-8")),
         group_id="agent-ingestion",
@@ -43,6 +44,7 @@ def store_event(conn, evt):
 
 def ingestion(kafka_bootstrap: str, pg_dsn: str):
     logger.info({"event": "ingestion.start", "kafka_bootstrap": kafka_bootstrap})
+    settings = Settings()
 
     # Graceful shutdown handling
     shutdown_requested = False
@@ -60,13 +62,15 @@ def ingestion(kafka_bootstrap: str, pg_dsn: str):
 
     try:
         conn = create_db_connection(pg_dsn)
-        cons = create_kafka_consumer(kafka_bootstrap)
+        cons = create_kafka_consumer(kafka_bootstrap, settings)
 
         for msg in cons:
             if shutdown_requested:
                 break
 
             evt = msg.value
+            if not event_in_scope(evt.get("org_id"), settings, org_id=settings.default_org):
+                continue
             if evt.get("event_type") == "event.raised":
                 try:
                     store_event(conn, evt)

--- a/maintenance_intelligence/services/rca_agent.py
+++ b/maintenance_intelligence/services/rca_agent.py
@@ -2,6 +2,7 @@ import os, json, uuid, datetime as dt, signal, sys
 from kafka import KafkaConsumer, KafkaProducer
 from kafka.errors import KafkaError
 from loguru import logger
+from maintenance_intelligence.multitenancy import consumer_topics, event_in_scope, scoped_topic
 from maintenance_intelligence.runner.config import Settings
 from maintenance_intelligence.genai.gateway import GenAIGateway
 from maintenance_intelligence.runner.summaries import write_run_summary
@@ -10,10 +11,10 @@ import backoff
 from maintenance_intelligence.api.metrics import recommendations_created_total, rca_runs_total, rca_failures_total, rca_duration_seconds
 
 @backoff.on_exception(backoff.expo, KafkaError, max_tries=5, max_time=60)
-def create_kafka_consumer(kafka_bootstrap: str):
+def create_kafka_consumer(kafka_bootstrap: str, settings: Settings):
     """Create Kafka consumer with retry logic."""
     return KafkaConsumer(
-        "canonical.event.raised",
+        *consumer_topics(["canonical.event.raised"], settings, org_id=settings.default_org),
         bootstrap_servers=kafka_bootstrap,
         value_deserializer=lambda v: json.loads(v.decode("utf-8")),
         group_id="agent-rca",
@@ -34,9 +35,9 @@ def create_kafka_producer(kafka_bootstrap: str):
     )
 
 @backoff.on_exception(backoff.expo, KafkaError, max_tries=3, max_time=30)
-def send_recommendation(producer, recommendation):
+def send_recommendation(producer, recommendation, settings: Settings):
     """Send recommendation with retry logic."""
-    producer.send("canonical.recommendation.created", recommendation)
+    producer.send(scoped_topic("canonical.recommendation.created", settings, recommendation.get("org_id")), recommendation)
     producer.flush()
 
 def rca_agent(kafka_bootstrap: str = None):
@@ -60,7 +61,7 @@ def rca_agent(kafka_bootstrap: str = None):
     prod = None
 
     try:
-        cons = create_kafka_consumer(kafka_bootstrap)
+        cons = create_kafka_consumer(kafka_bootstrap, settings)
         prod = create_kafka_producer(kafka_bootstrap)
 
         openai_key = os.getenv("OPENAI_API_KEY")
@@ -72,6 +73,8 @@ def rca_agent(kafka_bootstrap: str = None):
                 break
 
             evt = msg.value
+            if not event_in_scope(evt.get("org_id"), settings, org_id=settings.default_org):
+                continue
             if evt.get("kind") not in ("alarm", "anomaly"):
                 continue
 
@@ -80,7 +83,7 @@ def rca_agent(kafka_bootstrap: str = None):
 
             try:
                 # Assemble MVP context
-                ctx = get_event_context(evt, settings)
+                ctx = get_event_context(evt, settings, org_id=evt.get("org_id"))
 
                 if gateway:
                     g = gateway.call_rca(evt, ctx)
@@ -117,7 +120,7 @@ def rca_agent(kafka_bootstrap: str = None):
                     },
                 }
 
-                send_recommendation(prod, out)
+                send_recommendation(prod, out, settings)
 
                 run_id = out["event_id"]
                 write_run_summary(getattr(settings, "run_summary_dir", "outputs"), run_id, {

--- a/maintenance_intelligence/services/signals.py
+++ b/maintenance_intelligence/services/signals.py
@@ -3,6 +3,7 @@ from kafka import KafkaConsumer, KafkaProducer
 from kafka.errors import KafkaError
 from maintenance_intelligence.runner.config import Settings
 from maintenance_intelligence.runner.logging import get_logger
+from maintenance_intelligence.multitenancy import consumer_topics, event_in_scope, scoped_topic
 import psycopg2
 import psycopg2.extras
 from collections import defaultdict
@@ -12,9 +13,9 @@ import backoff
 logger = get_logger(__name__)
 
 @backoff.on_exception(backoff.expo, KafkaError, max_tries=5, max_time=60)
-def create_kafka_consumer(kafka_bootstrap: str):
+def create_kafka_consumer(kafka_bootstrap: str, settings: Settings):
     """Create Kafka consumer with retry logic."""
-    return KafkaConsumer("canonical.event.raised",
+    return KafkaConsumer(*consumer_topics(["canonical.event.raised"], settings, org_id=settings.default_org),
                          bootstrap_servers=kafka_bootstrap,
                          value_deserializer=lambda v: json.loads(v.decode("utf-8")),
                          auto_offset_reset="earliest",
@@ -39,9 +40,9 @@ def create_db_connection(db_url: str):
     return conn
 
 @backoff.on_exception(backoff.expo, KafkaError, max_tries=3, max_time=30)
-def send_anomaly_event(producer, anomaly_event):
+def send_anomaly_event(producer, anomaly_event, settings: Settings):
     """Send anomaly event with retry logic."""
-    producer.send("canonical.signal.anomaly.detected", anomaly_event)
+    producer.send(scoped_topic("canonical.signal.anomaly.detected", settings, anomaly_event.get("org_id")), anomaly_event)
     producer.flush()
 
 def signals_processor(kafka_bootstrap: str = None, db_url: str = None):
@@ -68,7 +69,7 @@ def signals_processor(kafka_bootstrap: str = None, db_url: str = None):
     conn = None
 
     try:
-        cons = create_kafka_consumer(kafka_bootstrap)
+        cons = create_kafka_consumer(kafka_bootstrap, settings)
         prod = create_kafka_producer(kafka_bootstrap)
         conn = create_db_connection(db_url)
 
@@ -80,6 +81,8 @@ def signals_processor(kafka_bootstrap: str = None, db_url: str = None):
                 break
 
             evt = msg.value
+            if not event_in_scope(evt.get("org_id"), settings, org_id=settings.default_org):
+                continue
             if evt.get("kind") not in ("alarm", "anomaly", "measurement"):
                 continue
 
@@ -137,7 +140,7 @@ def signals_processor(kafka_bootstrap: str = None, db_url: str = None):
                             },
                             "lineage": {"source": "signals-processor", "parent_event_id": evt["event_id"]},
                         }
-                        send_anomaly_event(prod, anomaly_evt)
+                        send_anomaly_event(prod, anomaly_evt, settings)
 
                 logger.info({"event": "signals.processed", "asset_id": asset_id, "signals_count": len(signals)})
 

--- a/maintenance_intelligence/services/simulator.py
+++ b/maintenance_intelligence/services/simulator.py
@@ -3,6 +3,8 @@ from kafka import KafkaProducer
 from kafka.errors import KafkaError
 from loguru import logger
 import backoff
+from maintenance_intelligence.multitenancy import scoped_topic
+from maintenance_intelligence.runner.config import Settings
 
 @backoff.on_exception(backoff.expo, KafkaError, max_tries=5, max_time=60)
 def create_kafka_producer(kafka_bootstrap: str):
@@ -16,14 +18,15 @@ def create_kafka_producer(kafka_bootstrap: str):
     )
 
 @backoff.on_exception(backoff.expo, KafkaError, max_tries=3, max_time=30)
-def send_event(producer, topic, event):
+def send_event(producer, topic, event, settings: Settings):
     """Send event with retry logic."""
-    future = producer.send(topic, event)
+    future = producer.send(scoped_topic(topic, settings, event.get("org_id")), event)
     producer.flush()  # Wait for send to complete
     return future
 
 def simulator(kafka_bootstrap: str):
     logger.info({"event": "simulator.start", "kafka_bootstrap": kafka_bootstrap})
+    settings = Settings()
 
     # Graceful shutdown handling
     shutdown_requested = False
@@ -60,7 +63,7 @@ def simulator(kafka_bootstrap: str):
                 }
 
                 try:
-                    send_event(prod, "canonical.event.raised", evt)
+                    send_event(prod, "canonical.event.raised", evt, settings)
                     logger.debug({"event": "simulator.sent", "asset_id": a, "event_id": evt["event_id"]})
                 except Exception as e:
                     logger.error({"event": "simulator.send_failed", "asset_id": a, "error": str(e)})

--- a/maintenance_intelligence/services/wo_bridge.py
+++ b/maintenance_intelligence/services/wo_bridge.py
@@ -3,6 +3,8 @@ from kafka import KafkaConsumer
 import psycopg2
 from loguru import logger
 from maintenance_intelligence.api.metrics import wo_drafts_total
+from maintenance_intelligence.multitenancy import consumer_topics, event_in_scope, scoped_topic
+from maintenance_intelligence.runner.config import Settings
 
 def with_pg(dsn: str):
     import time
@@ -13,25 +15,29 @@ def with_pg(dsn: str):
             time.sleep(1)
 
 def wo_bridge(kafka_bootstrap: str, pg_dsn: str):
+    settings = Settings()
     conn = with_pg(pg_dsn)
     cons = KafkaConsumer(
-        "canonical.recommendation.created",
+        *consumer_topics(["canonical.recommendation.created"], settings, org_id=settings.default_org),
         bootstrap_servers=kafka_bootstrap,
         value_deserializer=lambda v: json.loads(v.decode("utf-8")),
         group_id="agent-wo-bridge",
         auto_offset_reset="earliest",
     )
     for msg in cons:
+        if not event_in_scope(msg.value.get("org_id"), settings, org_id=settings.default_org):
+            continue
         rec = msg.value.get("recommendation", {})
         wo_id = f"WO-{rec.get('id','')[:8]}"
         with conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "INSERT INTO workorders (wo_id, asset_id, status, title, description, priority, metadata) "
-                    "VALUES (%s,%s,%s,%s,%s,%s,%s::jsonb) "
+                    "INSERT INTO workorders (wo_id, org_id, asset_id, status, title, description, priority, metadata) "
+                    "VALUES (%s,%s,%s,%s,%s,%s,%s,%s::jsonb) "
                     "ON CONFLICT (wo_id) DO NOTHING",
                     (
                         wo_id,
+                        msg.value.get("org_id") or settings.default_org,
                         rec.get("asset_id"),
                         "DRAFT",
                         rec.get("title"),

--- a/tests/test_context_tenant_scope.py
+++ b/tests/test_context_tenant_scope.py
@@ -1,0 +1,66 @@
+from maintenance_intelligence.context import assembler
+
+
+class _Cursor:
+    def __init__(self, calls):
+        self.calls = calls
+        self.rows = []
+
+    def execute(self, query, params=None):
+        self.calls.append((query, tuple(params or ())))
+        if "SELECT title FROM workorders" in query:
+            self.rows = [("Scoped WO",)]
+        else:
+            self.rows = []
+
+    def fetchall(self):
+        return self.rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _Conn:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def cursor(self, *args, **kwargs):
+        return _Cursor(self.calls)
+
+    def close(self):
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_context_uses_org_scope_and_forwards_org_to_retriever(monkeypatch):
+    calls = []
+    seen = {}
+    monkeypatch.setenv("MI_MULTI_TENANT", "true")
+    monkeypatch.setenv("MI_DEFAULT_ORG", "ORG-CTX")
+    monkeypatch.setattr(assembler, "with_pg", lambda _dsn: _Conn(calls))
+
+    from maintenance_intelligence.rag import retrieval as retrieval_mod
+
+    class FakeRetriever:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def retrieve(self, query, asset_id, limit=10, token_budget=4000, org_id=None):
+            seen["org_id"] = org_id
+            return []
+
+    monkeypatch.setattr(retrieval_mod, "HybridRetriever", FakeRetriever)
+
+    ctx = assembler.get_event_context({"asset_id": "ASSET-CTX", "org_id": "ORG-CTX", "kind": "alarm"})
+
+    assert ctx["asset_id"] == "ASSET-CTX"
+    assert any("org_id = %s" in query for query, _ in calls if "FROM workorders" in query)
+    assert seen["org_id"] == "ORG-CTX"

--- a/tests/test_multi_tenant_auth.py
+++ b/tests/test_multi_tenant_auth.py
@@ -1,0 +1,129 @@
+import datetime as dt
+import json
+
+from fastapi.testclient import TestClient
+
+from maintenance_intelligence.api.main import app
+from maintenance_intelligence.api import feedback as feedback_api
+from maintenance_intelligence.api import main as main_api
+from maintenance_intelligence.api import outcomes as outcomes_api
+
+
+class _Cursor:
+    def __init__(self, calls):
+        self.calls = calls
+        self.rows = []
+
+    def execute(self, query, params=None):
+        params = tuple(params or ())
+        self.calls.append((query, params))
+        normalized = " ".join(query.split())
+        if "FROM rca_feedback" in normalized and "GROUP BY action" in normalized:
+            self.rows = [("accept", 2), ("reject", 1)]
+        elif "FROM workorders w" in normalized and "COUNT(*) AS n" in normalized:
+            self.rows = [("ASSET-1", 3)]
+        elif normalized.startswith("SELECT wo_id, asset_id, metadata FROM workorders"):
+            self.rows = [(
+                "WO-1",
+                "ASSET-1",
+                {"created_at": "2026-03-14T10:00:00Z", "resolved_at": "2026-03-14T11:00:00Z"},
+            )]
+        elif normalized.startswith("SELECT event_id, asset_id, occurred_at FROM events"):
+            self.rows = [("EVT-1", "ASSET-1", dt.datetime(2026, 3, 14, 10, 30, tzinfo=dt.timezone.utc))]
+        elif "COUNT(*) FILTER (WHERE action = 'accept')" in normalized:
+            self.rows = [("ASSET-1", 2, 3)]
+        else:
+            self.rows = []
+
+    def fetchall(self):
+        return self.rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _Conn:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def cursor(self, *args, **kwargs):
+        return _Cursor(self.calls)
+
+    def close(self):
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_trigger_requires_operator_role(monkeypatch):
+    monkeypatch.setenv("MI_AUTH_MODE", "api_key")
+    monkeypatch.setenv(
+        "MI_API_KEYS",
+        json.dumps(
+            {
+                "viewer-key": {"org_id": "ORG-1", "role": "viewer"},
+                "operator-key": {"org_id": "ORG-1", "role": "operator"},
+            }
+        ),
+    )
+    monkeypatch.setattr(main_api, "run", lambda event_id, settings, org_id=None: {"event_id": event_id, "org_id": org_id})
+
+    client = TestClient(app)
+    denied = client.post("/api/v1/agents/rca/trigger", json={"event_id": "E-1"}, headers={"X-API-Key": "viewer-key"})
+    allowed = client.post("/api/v1/agents/rca/trigger", json={"event_id": "E-1"}, headers={"X-API-Key": "operator-key"})
+
+    assert denied.status_code == 403
+    assert allowed.status_code == 200
+    assert allowed.json()["org_id"] == "ORG-1"
+
+
+def test_feedback_uses_authenticated_org(monkeypatch):
+    calls = []
+    monkeypatch.setenv("MI_AUTH_MODE", "api_key")
+    monkeypatch.setenv("MI_API_KEYS", json.dumps({"operator-key": {"org_id": "ORG-9", "role": "operator"}}))
+    monkeypatch.setattr(feedback_api, "with_pg", lambda _dsn: _Conn(calls))
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/rca/feedback",
+        json={
+            "run_id": "RUN-1",
+            "recommendation_id": "REC-1",
+            "action": "accept",
+            "asset_id": "ASSET-9",
+        },
+        headers={"X-API-Key": "operator-key"},
+    )
+
+    assert response.status_code == 200
+    insert_call = next(params for query, params in calls if "INSERT INTO rca_feedback" in query)
+    assert insert_call[3] == "ORG-9"
+    assert insert_call[4] == "ASSET-9"
+
+
+def test_outcomes_queries_are_org_scoped(monkeypatch):
+    calls = []
+    monkeypatch.setenv("MI_MULTI_TENANT", "true")
+    monkeypatch.setenv("MI_AUTH_MODE", "api_key")
+    monkeypatch.setenv("MI_API_KEYS", json.dumps({"viewer-key": {"org_id": "ORG-1", "role": "viewer"}}))
+    monkeypatch.setattr(outcomes_api, "with_pg", lambda _dsn: _Conn(calls))
+
+    client = TestClient(app)
+    response = client.get("/api/v1/reports/rca-outcomes?window=30", headers={"X-API-Key": "viewer-key"})
+
+    assert response.status_code == 200
+    relevant_calls = [
+        (query, params)
+        for query, params in calls
+        if "FROM rca_feedback" in query or "FROM workorders" in query or "FROM events" in query
+    ]
+    assert relevant_calls
+    assert all("org_id" in query for query, _ in relevant_calls)
+    assert any("ORG-1" in params for _, params in relevant_calls)


### PR DESCRIPTION
## Summary
- add tenant-aware request auth with API-key role resolution for `viewer`, `operator`, and `admin`
- scope outcomes, feedback, bad-actors, context assembly, and RAG document retrieval by org when `MI_MULTI_TENANT=true`
- add migration support for `workorders.org_id` and `doc_chunks.org_id`, plus tenant-aware Kafka topic helpers and worker filtering

## Config
- `MI_MULTI_TENANT=true|false`
- `MI_DEFAULT_ORG=<org>`
- `MI_AUTH_MODE=none|api_key`
- `MI_API_KEYS={"key":{"org_id":"org-a","role":"viewer"}}`
- `MI_KAFKA_TENANT_MODE=message|namespaced`

## Validation
- `/home/codespace/.python/current/bin/python -m py_compile maintenance_intelligence/api/main.py maintenance_intelligence/api/outcomes.py maintenance_intelligence/api/feedback.py maintenance_intelligence/api/reports.py maintenance_intelligence/context/assembler.py maintenance_intelligence/rag/retrieval.py maintenance_intelligence/runner/config.py maintenance_intelligence/api/auth.py maintenance_intelligence/multitenancy.py`
- `/home/codespace/.python/current/bin/python -m py_compile maintenance_intelligence/services/ingestion.py maintenance_intelligence/services/rca_agent.py maintenance_intelligence/services/signals.py maintenance_intelligence/services/simulator.py maintenance_intelligence/services/wo_bridge.py maintenance_intelligence/rag/ingest.py maintenance_intelligence/api/signals.py`
- `/home/codespace/.python/current/bin/python -m pytest -q tests/test_multi_tenant_auth.py tests/test_context_tenant_scope.py tests/test_outcomes_shape.py tests/test_outcomes_ttr_join.py`
- `/home/codespace/.python/current/bin/python -m pytest -q tests/test_outcomes_csv.py tests/test_outcomes_import.py tests/test_reports_import.py tests/test_api_health.py`