### PR TITLE
fix(signals): isolate signal reads and rollups by org

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,9 @@ Notes:
   - enable `MI_MULTI_TENANT=true`
   - provision per-org API keys via `MI_API_KEYS`
   - run workers with the org selected by `MI_DEFAULT_ORG` when using namespaced Kafka topics
+
+## Signals Tenant Isolation
+
+- `signals` and `signal_rollups` now carry `org_id` for end-to-end tenant isolation in the context path.
+- Signal ingestion writes `org_id` from the incoming event, falls back to `lineage.org_id`, and then to `MI_DEFAULT_ORG`.
+- The SQL migration backfills existing `signals.org_id` from stored metadata where available; historical rollups without source org metadata may remain null until recomputed.

--- a/maintenance_intelligence/api/signals.py
+++ b/maintenance_intelligence/api/signals.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import List, Optional
 import psycopg2
 from maintenance_intelligence.api.auth import require_role
-from maintenance_intelligence.multitenancy import TenantContext
+from maintenance_intelligence.multitenancy import TenantContext, org_scope_enabled
 from maintenance_intelligence.runner.config import Settings
 from maintenance_intelligence.context.assembler import with_pg
 
@@ -19,24 +19,25 @@ async def get_signals_summary(
     try:
         conn = with_pg(settings.pg_dsn)
         with conn, conn.cursor() as cur:
+            scope_enabled = org_scope_enabled(settings)
             # Get recent signals
             cur.execute("""
                 SELECT signal_id, signal_type, value, unit, timestamp, metadata
                 FROM signals
-                WHERE asset_id = %s
+                WHERE asset_id = %s AND (%s = FALSE OR org_id = %s)
                 ORDER BY timestamp DESC
                 LIMIT %s
-            """, (asset_id, limit))
+            """, (asset_id, scope_enabled, access.org_id, limit))
             signals = cur.fetchall()
 
             # Get latest rollups
             cur.execute("""
                 SELECT signal_type, period, mean_value, min_value, max_value, anomaly_flags, end_time
                 FROM signal_rollups
-                WHERE asset_id = %s
+                WHERE asset_id = %s AND (%s = FALSE OR org_id = %s)
                 ORDER BY end_time DESC
                 LIMIT 20
-            """, (asset_id,))
+            """, (asset_id, scope_enabled, access.org_id))
             rollups = cur.fetchall()
 
         return {

--- a/maintenance_intelligence/context/assembler.py
+++ b/maintenance_intelligence/context/assembler.py
@@ -54,10 +54,10 @@ def get_event_context(event: Dict[str, Any], settings: Optional[Settings] = None
                 cur.execute("""
                     SELECT signal_type, period, mean_value, min_value, max_value, anomaly_flags
                     FROM signal_rollups
-                    WHERE asset_id = %s AND end_time >= NOW() - INTERVAL '24 hours'
+                    WHERE asset_id = %s AND (%s = FALSE OR org_id = %s) AND end_time >= NOW() - INTERVAL '24 hours'
                     ORDER BY end_time DESC
                     LIMIT 10
-                """, (asset_id,))
+                """, (asset_id, org_scope_enabled(settings), effective_org_id))
                 rollups = cur.fetchall()
                 out["signal_rollups"] = [
                     {
@@ -74,10 +74,10 @@ def get_event_context(event: Dict[str, Any], settings: Optional[Settings] = None
                 cur.execute("""
                     SELECT signal_id, signal_type, value, timestamp, metadata
                     FROM signals
-                    WHERE asset_id = %s AND timestamp >= NOW() - INTERVAL '1 hour'
+                    WHERE asset_id = %s AND (%s = FALSE OR org_id = %s) AND timestamp >= NOW() - INTERVAL '1 hour'
                     ORDER BY timestamp DESC
                     LIMIT 20
-                """, (asset_id,))
+                """, (asset_id, org_scope_enabled(settings), effective_org_id))
                 signals = cur.fetchall()
                 out["recent_signals"] = [
                     {

--- a/maintenance_intelligence/db/alembic/versions/003_signals_org_scope.py
+++ b/maintenance_intelligence/db/alembic/versions/003_signals_org_scope.py
@@ -1,0 +1,31 @@
+"""Add org_id columns to signals and signal_rollups
+
+Revision ID: 003_signals_org_scope
+Revises: 002_multi_tenant_rbac
+Create Date: 2026-03-14 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "003_signals_org_scope"
+down_revision: Union[str, None] = "002_multi_tenant_rbac"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("signals", sa.Column("org_id", sa.Text(), nullable=True))
+    op.add_column("signal_rollups", sa.Column("org_id", sa.Text(), nullable=True))
+    op.create_index("idx_signals_org_asset_time", "signals", ["org_id", "asset_id", "timestamp"], unique=False)
+    op.create_index("idx_rollups_org_asset_end", "signal_rollups", ["org_id", "asset_id", "end_time"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("idx_rollups_org_asset_end", table_name="signal_rollups")
+    op.drop_index("idx_signals_org_asset_time", table_name="signals")
+    op.drop_column("signal_rollups", "org_id")
+    op.drop_column("signals", "org_id")

--- a/maintenance_intelligence/db/migrations/003_signals.sql
+++ b/maintenance_intelligence/db/migrations/003_signals.sql
@@ -1,6 +1,7 @@
 -- signals table for time-series measurements and rollups
 CREATE TABLE IF NOT EXISTS signals (
   signal_id TEXT PRIMARY KEY,
+  org_id TEXT,
   asset_id TEXT,
   signal_type TEXT,  -- e.g., 'vibration', 'temperature'
   timestamp TIMESTAMPTZ,
@@ -13,6 +14,7 @@ CREATE TABLE IF NOT EXISTS signals (
 -- rollups table for aggregated signals
 CREATE TABLE IF NOT EXISTS signal_rollups (
   rollup_id TEXT PRIMARY KEY,
+  org_id TEXT,
   asset_id TEXT,
   signal_type TEXT,
   period TEXT,  -- '1h', '6h', '24h'
@@ -29,3 +31,5 @@ CREATE TABLE IF NOT EXISTS signal_rollups (
 -- indexes for efficient queries
 CREATE INDEX IF NOT EXISTS idx_signals_asset_type_time ON signals (asset_id, signal_type, timestamp);
 CREATE INDEX IF NOT EXISTS idx_rollups_asset_type_period ON signal_rollups (asset_id, signal_type, period, start_time DESC);
+CREATE INDEX IF NOT EXISTS idx_signals_org_asset_time ON signals (org_id, asset_id, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_rollups_org_asset_end ON signal_rollups (org_id, asset_id, end_time DESC);

--- a/maintenance_intelligence/db/migrations/006_signals_org_scope.sql
+++ b/maintenance_intelligence/db/migrations/006_signals_org_scope.sql
@@ -1,0 +1,13 @@
+ALTER TABLE signals ADD COLUMN IF NOT EXISTS org_id TEXT;
+ALTER TABLE signal_rollups ADD COLUMN IF NOT EXISTS org_id TEXT;
+
+UPDATE signals
+SET org_id = COALESCE(org_id, metadata->>'org_id', metadata->>'source_org_id')
+WHERE org_id IS NULL;
+
+UPDATE signal_rollups
+SET org_id = COALESCE(org_id, anomaly_flags->>'org_id')
+WHERE org_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_signals_org_asset_time ON signals (org_id, asset_id, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_rollups_org_asset_end ON signal_rollups (org_id, asset_id, end_time DESC);

--- a/maintenance_intelligence/services/signals.py
+++ b/maintenance_intelligence/services/signals.py
@@ -12,6 +12,11 @@ import backoff
 
 logger = get_logger(__name__)
 
+
+def _resolve_signal_org_id(evt: dict, settings: Settings) -> str:
+    lineage = evt.get("lineage") if isinstance(evt.get("lineage"), dict) else {}
+    return evt.get("org_id") or lineage.get("org_id") or settings.default_org
+
 @backoff.on_exception(backoff.expo, KafkaError, max_tries=5, max_time=60)
 def create_kafka_consumer(kafka_bootstrap: str, settings: Settings):
     """Create Kafka consumer with retry logic."""
@@ -88,6 +93,7 @@ def signals_processor(kafka_bootstrap: str = None, db_url: str = None):
 
             try:
                 asset_id = evt.get("asset_id")
+                org_id = _resolve_signal_org_id(evt, settings)
                 details = evt.get("details", {})
 
                 # Extract signals from details (assume vibration, temperature, etc.)
@@ -104,20 +110,20 @@ def signals_processor(kafka_bootstrap: str = None, db_url: str = None):
                     # Insert signal
                     with conn.cursor() as cur:
                         cur.execute("""
-                            INSERT INTO signals (signal_id, asset_id, signal_type, timestamp, value, unit, metadata)
-                            VALUES (%s, %s, %s, %s, %s, %s, %s)
+                            INSERT INTO signals (signal_id, org_id, asset_id, signal_type, timestamp, value, unit, metadata)
+                            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                             ON CONFLICT (signal_id) DO NOTHING
-                        """, (signal_id, asset_id, signal_type, evt["occurred_at"], value, unit,
-                              {"event_id": evt["event_id"], "source": "event"}))
+                        """, (signal_id, org_id, asset_id, signal_type, evt["occurred_at"], value, unit,
+                              {"event_id": evt["event_id"], "source": "event", "org_id": org_id}))
 
                     # Update recent values for anomaly detection
-                    key = (asset_id, signal_type)
+                    key = (org_id, asset_id, signal_type)
                     recent_values[key].append(value)
                     if len(recent_values[key]) > 100:  # Keep last 100 values
                         recent_values[key].pop(0)
 
                     # Compute rollups every 5 minutes (in real system, use cron or scheduler)
-                    _compute_rollups(conn, asset_id, signal_type)
+                    _compute_rollups(conn, org_id, asset_id, signal_type)
 
                     # Detect anomalies
                     anomaly_flags = _detect_anomalies(recent_values[key], value, details.get("threshold"))
@@ -127,7 +133,7 @@ def signals_processor(kafka_bootstrap: str = None, db_url: str = None):
                             "event_type": "signal.anomaly.detected",
                             "event_id": f"anomaly-{signal_id}",
                             "occurred_at": dt.datetime.utcnow().isoformat() + "Z",
-                            "org_id": evt["org_id"],
+                            "org_id": org_id,
                             "asset_id": asset_id,
                             "kind": "anomaly",
                             "severity": "medium",
@@ -163,7 +169,7 @@ def signals_processor(kafka_bootstrap: str = None, db_url: str = None):
 
     logger.info({"event": "signals_processor.exit"})
 
-def _compute_rollups(conn, asset_id: str, signal_type: str):
+def _compute_rollups(conn, org_id: str, asset_id: str, signal_type: str):
     """Compute 1h, 6h, 24h rollups for the last period."""
     now = dt.datetime.utcnow()
     periods = [
@@ -178,9 +184,9 @@ def _compute_rollups(conn, asset_id: str, signal_type: str):
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute("""
                 SELECT value FROM signals
-                WHERE asset_id = %s AND signal_type = %s AND timestamp >= %s
+                WHERE org_id = %s AND asset_id = %s AND signal_type = %s AND timestamp >= %s
                 ORDER BY timestamp
-            """, (asset_id, signal_type, start_time))
+            """, (org_id, asset_id, signal_type, start_time))
 
             values = [row["value"] for row in cur.fetchall()]
             if not values:
@@ -201,17 +207,18 @@ def _compute_rollups(conn, asset_id: str, signal_type: str):
             rollup_id = f"{asset_id}-{signal_type}-{period_name}-{now.isoformat()}"
 
             cur.execute("""
-                INSERT INTO signal_rollups (rollup_id, asset_id, signal_type, period, start_time, end_time,
+                INSERT INTO signal_rollups (rollup_id, org_id, asset_id, signal_type, period, start_time, end_time,
                                            mean_value, min_value, max_value, count, anomaly_flags)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (rollup_id) DO UPDATE SET
+                    org_id = EXCLUDED.org_id,
                     mean_value = EXCLUDED.mean_value,
                     min_value = EXCLUDED.min_value,
                     max_value = EXCLUDED.max_value,
                     count = EXCLUDED.count,
                     anomaly_flags = EXCLUDED.anomaly_flags
-            """, (rollup_id, asset_id, signal_type, period_name, start_time, now,
-                  mean_val, min_val, max_val, count, json.dumps(anomaly_flags)))
+            """, (rollup_id, org_id, asset_id, signal_type, period_name, start_time, now,
+                  mean_val, min_val, max_val, count, json.dumps({**anomaly_flags, "org_id": org_id})))
 
 def _detect_anomalies(recent_values: list, current_value: float, threshold: float = None) -> dict:
     """Simple anomaly detection using z-score and threshold."""

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,7 +1,8 @@
 import pytest
-from maintenance_intelligence.services.signals import _detect_anomalies, _compute_rollups
+from maintenance_intelligence.services.signals import _detect_anomalies, _compute_rollups, _resolve_signal_org_id
 import psycopg2
 from unittest.mock import MagicMock
+from maintenance_intelligence.runner.config import Settings
 
 def test_detect_anomalies():
     # Normal values
@@ -26,10 +27,23 @@ def test_compute_rollups():
     # Mock signal data
     mock_cur.fetchall.return_value = [{"value": 1.0}, {"value": 2.0}, {"value": 3.0}]
 
-    _compute_rollups(mock_conn, "PUMP-101", "vibration")
+    _compute_rollups(mock_conn, "ORG-1", "PUMP-101", "vibration")
 
     # Verify queries were made
     assert mock_cur.execute.called
     # Check that insert was called
     calls = mock_cur.execute.call_args_list
     assert len(calls) >= 2  # Select and insert
+    select_params = calls[0][0][1]
+    insert_params = calls[1][0][1]
+    assert select_params[0] == "ORG-1"
+    assert insert_params[1] == "ORG-1"
+
+
+def test_resolve_signal_org_id_prefers_event_then_lineage_then_default(monkeypatch):
+    monkeypatch.setenv("MI_DEFAULT_ORG", "ORG-DEFAULT")
+    settings = Settings()
+
+    assert _resolve_signal_org_id({"org_id": "ORG-EVT", "lineage": {"org_id": "ORG-LINEAGE"}}, settings) == "ORG-EVT"
+    assert _resolve_signal_org_id({"lineage": {"org_id": "ORG-LINEAGE"}}, settings) == "ORG-LINEAGE"
+    assert _resolve_signal_org_id({}, settings) == "ORG-DEFAULT"

--- a/tests/test_signals_tenant_scope.py
+++ b/tests/test_signals_tenant_scope.py
@@ -1,0 +1,84 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from maintenance_intelligence.api.main import app
+from maintenance_intelligence.context import assembler
+from maintenance_intelligence.api import signals as signals_api
+
+
+class _Cursor:
+    def __init__(self, calls):
+        self.calls = calls
+        self.rows = []
+
+    def execute(self, query, params=None):
+        params = tuple(params or ())
+        self.calls.append((query, params))
+        normalized = " ".join(query.split())
+        if "FROM signals" in normalized:
+            self.rows = [("SIG-1", "vibration", 7.2, "mm/s", None, {"org_id": params[2] if len(params) > 2 else "ORG-A"})]
+        elif "FROM signal_rollups" in normalized:
+            self.rows = [("vibration", "1h", 7.2, 6.8, 8.1, {"org_id": params[2] if len(params) > 2 else "ORG-A"}, None)]
+        elif "SELECT title FROM workorders" in normalized:
+            self.rows = []
+        else:
+            self.rows = []
+
+    def fetchall(self):
+        return self.rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _Conn:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def cursor(self, *args, **kwargs):
+        return _Cursor(self.calls)
+
+    def close(self):
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_signals_summary_api_scopes_queries_by_org(monkeypatch):
+    calls = []
+    monkeypatch.setenv("MI_MULTI_TENANT", "true")
+    monkeypatch.setenv("MI_AUTH_MODE", "api_key")
+    monkeypatch.setenv("MI_API_KEYS", json.dumps({"viewer-key": {"org_id": "ORG-A", "role": "viewer"}}))
+    monkeypatch.setattr(signals_api, "with_pg", lambda _dsn: _Conn(calls))
+
+    client = TestClient(app)
+    response = client.get("/api/v1/signals/summary?asset_id=ASSET-1&limit=5", headers={"X-API-Key": "viewer-key"})
+
+    assert response.status_code == 200
+    relevant = [(query, params) for query, params in calls if "FROM signals" in query or "FROM signal_rollups" in query]
+    assert relevant
+    assert all("org_id = %s" in query for query, _ in relevant)
+    assert all("ORG-A" in params for _, params in relevant)
+
+
+def test_context_signal_queries_are_org_scoped(monkeypatch):
+    calls = []
+    monkeypatch.setenv("MI_MULTI_TENANT", "true")
+    monkeypatch.setenv("MI_DEFAULT_ORG", "ORG-A")
+    monkeypatch.setattr(assembler, "with_pg", lambda _dsn: _Conn(calls))
+
+    ctx = assembler.get_event_context({"asset_id": "ASSET-1", "org_id": "ORG-A", "kind": "alarm"})
+
+    assert ctx["asset_id"] == "ASSET-1"
+    signal_queries = [(query, params) for query, params in calls if "FROM signals" in query or "FROM signal_rollups" in query]
+    assert signal_queries
+    assert all("org_id = %s" in query for query, _ in signal_queries)
+    assert all("ORG-A" in params for _, params in signal_queries)


### PR DESCRIPTION
## Summary
- add `org_id` to `signals` and `signal_rollups` migrations plus org/asset/time indexes
- propagate signal org from the source event, fallback lineage, then `MI_DEFAULT_ORG`, and carry it into rollups
- scope signal reads in the assembler and `/api/v1/signals/summary` so tenant A cannot see tenant B signal data

## Validation
- `/home/codespace/.python/current/bin/python -m py_compile maintenance_intelligence/services/signals.py maintenance_intelligence/context/assembler.py maintenance_intelligence/api/signals.py maintenance_intelligence/db/alembic/versions/003_signals_org_scope.py`
- `/home/codespace/.python/current/bin/python -m pytest -q tests/test_signals.py tests/test_signals_tenant_scope.py tests/test_context_tenant_scope.py`
- `/home/codespace/.python/current/bin/python -m pytest -q tests/test_context_smoke.py tests/test_api_health.py tests/test_outcomes_shape.py`