### PR TITLE
Add prompt catalog and A/B routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,8 @@ MI_DEFAULT_ORG=default-org
 MI_AUTH_MODE=none
 MI_API_KEYS={"demo-viewer":{"org_id":"default-org","role":"viewer"}}
 MI_KAFKA_TENANT_MODE=message
+
+# Prompt Catalog / A-B
+MI_PROMPT_DEFAULTS={"rca":"rca-default-v1"}
+MI_PROMPT_CANARY_DEFAULTS={"rca":"rca-canary-v1"}
+MI_PROMPT_CANARY_RATIO=0.1

--- a/README.md
+++ b/README.md
@@ -175,3 +175,11 @@ Notes:
 - `signals` and `signal_rollups` now carry `org_id` for end-to-end tenant isolation in the context path.
 - Signal ingestion writes `org_id` from the incoming event, falls back to `lineage.org_id`, and then to `MI_DEFAULT_ORG`.
 - The SQL migration backfills existing `signals.org_id` from stored metadata where available; historical rollups without source org metadata may remain null until recomputed.
+
+## Prompt Catalog and A/B Testing
+
+- Prompt templates are versioned in `prompt_catalog` with IDs, route ownership, descriptions, and intended-use metadata.
+- Route-level defaults and org-specific overrides are stored in `prompt_route_configs`.
+- `MI_PROMPT_DEFAULTS` and `MI_PROMPT_CANARY_DEFAULTS` provide config-backed fallbacks when no DB override exists.
+- `MI_PROMPT_CANARY_RATIO` controls the default canary split; the RCA agent records `prompt_id` and variant in run summaries and recommendation model metadata.
+- Feedback can carry `prompt_id` and `prompt_route`, enabling prompt quality tracking via `prompt_feedback_total` and auto-rollback decisions.

--- a/maintenance_intelligence/api/feedback.py
+++ b/maintenance_intelligence/api/feedback.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 from maintenance_intelligence.runner.config import Settings
 from maintenance_intelligence.api.auth import require_role
 from maintenance_intelligence.context.assembler import with_pg
-from maintenance_intelligence.api.metrics import REGISTRY
+from maintenance_intelligence.api.metrics import REGISTRY, prompt_feedback_total
 from maintenance_intelligence.multitenancy import TenantContext
 from prometheus_client import Counter
 
@@ -22,6 +22,8 @@ class FeedbackPayload(BaseModel):
     reason: Optional[str] = None
     user_id: Optional[str] = None
     asset_id: Optional[str] = None
+    prompt_id: Optional[str] = None
+    prompt_route: str = Field(default="rca", description="Route associated with the prompt")
 
 @router.post("/feedback")
 def submit_feedback(p: FeedbackPayload, access: TenantContext = Depends(require_role("operator"))):
@@ -34,13 +36,27 @@ def submit_feedback(p: FeedbackPayload, access: TenantContext = Depends(require_
         with conn, conn.cursor() as cur:
             cur.execute(
                 """
-                INSERT INTO rca_feedback(id, run_id, recommendation_id, org_id, asset_id, action, changes, reason, user_id)
-                VALUES (%s,%s,%s,%s,%s,%s,%s::jsonb,%s,%s)
+                INSERT INTO rca_feedback(id, run_id, recommendation_id, org_id, asset_id, prompt_id, prompt_route, action, changes, reason, user_id)
+                VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb,%s,%s)
                 """,
-                (fid, p.run_id, p.recommendation_id, access.org_id, p.asset_id, p.action, json.dumps(p.changes) if p.changes else None, p.reason, p.user_id)
+                (
+                    fid,
+                    p.run_id,
+                    p.recommendation_id,
+                    access.org_id,
+                    p.asset_id,
+                    p.prompt_id,
+                    p.prompt_route,
+                    p.action,
+                    json.dumps(p.changes) if p.changes else None,
+                    p.reason,
+                    p.user_id,
+                )
             )
         try:
             feedback_total.labels(action=p.action).inc()
+            if p.prompt_id:
+                prompt_feedback_total.labels(route=p.prompt_route, prompt_id=p.prompt_id, action=p.action).inc()
         except Exception:
             pass
         return {"status":"ok","feedback_id":fid}

--- a/maintenance_intelligence/api/main.py
+++ b/maintenance_intelligence/api/main.py
@@ -2,6 +2,7 @@ from fastapi import Depends, FastAPI
 from pydantic import BaseModel
 
 from maintenance_intelligence.api.auth import require_role
+from maintenance_intelligence.api.prompts import router as prompts_router
 from maintenance_intelligence.api.reports import router as reports_router
 from maintenance_intelligence.api.health import router as health_router
 from maintenance_intelligence.api.signals import router as signals_router
@@ -21,6 +22,7 @@ app.include_router(signals_router)
 app.include_router(feedback_router)
 app.include_router(outcomes_router)
 app.include_router(metrics_router)
+app.include_router(prompts_router)
 settings = Settings()
 setup_logger(settings.log_level)
 init_tracing("maintenance-intelligence-api")

--- a/maintenance_intelligence/api/metrics.py
+++ b/maintenance_intelligence/api/metrics.py
@@ -14,6 +14,18 @@ rca_duration_seconds = Histogram("rca_duration_seconds", "RCA run duration (seco
 events_ingested_total = Counter("events_ingested_total", "Total events ingested", ["service"], registry=REGISTRY)
 recommendations_created_total = Counter("recommendations_created_total", "Total recommendations created", ["service"], registry=REGISTRY)
 wo_drafts_total = Counter("wo_drafts_total", "Total WO drafts created", ["service"], registry=REGISTRY)
+rca_runs_by_prompt_total = Counter(
+    "rca_runs_by_prompt_total",
+    "Total RCA runs by route and prompt",
+    ["service", "route", "prompt_id", "variant"],
+    registry=REGISTRY,
+)
+prompt_feedback_total = Counter(
+    "prompt_feedback_total",
+    "Total prompt-linked feedback items",
+    ["route", "prompt_id", "action"],
+    registry=REGISTRY,
+)
 
 # Kafka lag gauge (optional; set by health checks if desired)
 kafka_consume_lag = Gauge("kafka_consume_lag", "Kafka consumer group lag (total)", ["group"], registry=REGISTRY)

--- a/maintenance_intelligence/api/prompts.py
+++ b/maintenance_intelligence/api/prompts.py
@@ -1,0 +1,57 @@
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from maintenance_intelligence.api.auth import require_role
+from maintenance_intelligence.context.assembler import with_pg
+from maintenance_intelligence.multitenancy import TenantContext
+from maintenance_intelligence.prompts.catalog import list_prompts, load_route_config, save_route_config
+from maintenance_intelligence.runner.config import Settings
+
+
+router = APIRouter(prefix="/api/v1/prompts", tags=["prompts"])
+
+
+class PromptRouteConfigPayload(BaseModel):
+    org_id: Optional[str] = Field(default=None, description="Optional org-specific override; omit for global")
+    default_prompt_id: str
+    canary_prompt_id: Optional[str] = None
+    canary_ratio: float = Field(default=0.0, ge=0.0, le=1.0)
+    auto_rollback_enabled: bool = True
+    rollback_min_runs: int = Field(default=20, ge=1)
+    rollback_acceptance_delta: float = Field(default=0.05, ge=0.0, le=1.0)
+
+
+@router.get("")
+def get_prompts(
+    route: Optional[str] = Query(default=None),
+    access: TenantContext = Depends(require_role("viewer")),
+) -> Dict[str, Any]:
+    settings = Settings()
+    conn = with_pg(settings.pg_dsn)
+    try:
+        prompts = list_prompts(conn, route_name=route)
+        configs = {}
+        if route:
+            configs["effective"] = load_route_config(conn, settings, route, access.org_id)
+        return {"prompts": prompts, "configs": configs}
+    finally:
+        conn.close()
+
+
+@router.put("/routes/{route_name}")
+def put_prompt_route_config(
+    route_name: str,
+    payload: PromptRouteConfigPayload,
+    access: TenantContext = Depends(require_role("admin")),
+) -> Dict[str, Any]:
+    settings = Settings()
+    conn = with_pg(settings.pg_dsn)
+    try:
+        saved = save_route_config(conn, route_name, payload.org_id, payload.model_dump())
+        return {"status": "ok", "config": saved, "actor_org_id": access.org_id}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Prompt config update failed: {exc}") from exc
+    finally:
+        conn.close()

--- a/maintenance_intelligence/db/alembic/versions/004_prompt_catalog.py
+++ b/maintenance_intelligence/db/alembic/versions/004_prompt_catalog.py
@@ -1,0 +1,63 @@
+"""Add prompt catalog, route config, and feedback prompt tracking
+
+Revision ID: 004_prompt_catalog
+Revises: 003_signals_org_scope
+Create Date: 2026-03-14 12:15:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "004_prompt_catalog"
+down_revision: Union[str, None] = "003_signals_org_scope"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "prompt_catalog",
+        sa.Column("prompt_id", sa.Text(), nullable=False),
+        sa.Column("route_name", sa.Text(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("intended_use", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("system_prompt", sa.Text(), nullable=False),
+        sa.Column("user_prompt_template", sa.Text(), nullable=False),
+        sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True, server_default=sa.text("now()")),
+        sa.PrimaryKeyConstraint("prompt_id"),
+    )
+    op.create_table(
+        "prompt_route_configs",
+        sa.Column("config_id", sa.Text(), nullable=False),
+        sa.Column("org_id", sa.Text(), nullable=True),
+        sa.Column("route_name", sa.Text(), nullable=False),
+        sa.Column("default_prompt_id", sa.Text(), nullable=False),
+        sa.Column("canary_prompt_id", sa.Text(), nullable=True),
+        sa.Column("canary_ratio", sa.Float(), nullable=False, server_default="0.0"),
+        sa.Column("auto_rollback_enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("rollback_min_runs", sa.Integer(), nullable=False, server_default="20"),
+        sa.Column("rollback_acceptance_delta", sa.Float(), nullable=False, server_default="0.05"),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True, server_default=sa.text("now()")),
+        sa.PrimaryKeyConstraint("config_id"),
+    )
+    op.add_column("rca_feedback", sa.Column("prompt_id", sa.Text(), nullable=True))
+    op.add_column("rca_feedback", sa.Column("prompt_route", sa.Text(), nullable=True))
+    op.create_index("idx_prompt_catalog_route_active", "prompt_catalog", ["route_name", "active"], unique=False)
+    op.create_index("idx_prompt_configs_org_route", "prompt_route_configs", ["org_id", "route_name"], unique=False)
+    op.create_index("idx_feedback_prompt", "rca_feedback", ["prompt_id", "action"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("idx_feedback_prompt", table_name="rca_feedback")
+    op.drop_index("idx_prompt_configs_org_route", table_name="prompt_route_configs")
+    op.drop_index("idx_prompt_catalog_route_active", table_name="prompt_catalog")
+    op.drop_column("rca_feedback", "prompt_route")
+    op.drop_column("rca_feedback", "prompt_id")
+    op.drop_table("prompt_route_configs")
+    op.drop_table("prompt_catalog")

--- a/maintenance_intelligence/db/migrations/007_prompt_catalog.sql
+++ b/maintenance_intelligence/db/migrations/007_prompt_catalog.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS prompt_catalog (
+  prompt_id TEXT PRIMARY KEY,
+  route_name TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  description TEXT NOT NULL,
+  intended_use JSONB,
+  system_prompt TEXT NOT NULL,
+  user_prompt_template TEXT NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS prompt_route_configs (
+  config_id TEXT PRIMARY KEY,
+  org_id TEXT,
+  route_name TEXT NOT NULL,
+  default_prompt_id TEXT NOT NULL,
+  canary_prompt_id TEXT,
+  canary_ratio FLOAT NOT NULL DEFAULT 0.0,
+  auto_rollback_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  rollback_min_runs INTEGER NOT NULL DEFAULT 20,
+  rollback_acceptance_delta FLOAT NOT NULL DEFAULT 0.05,
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE rca_feedback ADD COLUMN IF NOT EXISTS prompt_id TEXT;
+ALTER TABLE rca_feedback ADD COLUMN IF NOT EXISTS prompt_route TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_prompt_catalog_route_active ON prompt_catalog (route_name, active);
+CREATE INDEX IF NOT EXISTS idx_prompt_configs_org_route ON prompt_route_configs (org_id, route_name);
+CREATE INDEX IF NOT EXISTS idx_feedback_prompt ON rca_feedback (prompt_id, action);

--- a/maintenance_intelligence/genai/gateway.py
+++ b/maintenance_intelligence/genai/gateway.py
@@ -14,14 +14,14 @@ class GenAIGateway:
             raise RuntimeError("openai package not installed")
         self.client = OpenAI(api_key=api_key)
 
-    def call_rca(self, event: Dict[str, Any], context: Dict[str, Any]) -> Dict[str, Any]:
+    def call_rca(self, event: Dict[str, Any], context: Dict[str, Any], prompt_selection: Dict[str, Any] | None = None) -> Dict[str, Any]:
         t0 = time.time()
-        prompt = self._build_prompt(event, context)
+        system_prompt, prompt = self._build_prompt(event, context, prompt_selection=prompt_selection)
         try:
             resp = self.client.chat.completions.create(
                 model=self.model,
                 messages=[
-                    {"role": "system", "content": "You are an industrial maintenance RCA assistant. Be concise and cite signals/WOs/docs when possible."},
+                    {"role": "system", "content": system_prompt},
                     {"role": "user", "content": prompt},
                 ],
                 temperature=0.2,
@@ -40,26 +40,30 @@ class GenAIGateway:
             "model_version": self.model,
             "tokens": tokens,
             "latency_ms": latency,
+            "structured": self._parse_structured(text),
+            "prompt_id": (prompt_selection or {}).get("prompt_id"),
         }
 
-    
-    def _build_prompt(self, event: Dict[str, Any], context: Dict[str, Any]) -> str:
-        lines = []
-        lines.append("You are an industrial maintenance RCA assistant. Respond with STRICT JSON only.")
-        lines.append("Do NOT include markdown, backticks, or commentary — return ONLY the JSON object.")
-        lines.append("Use this schema and fill every field; if unknown, produce your best estimate:")
-        lines.append('\nSCHEMA (strict JSON; do not include extra keys):\n{\n  "title": "string",\n  "hypothesis": ["string", "..."],\n  "evidence_ids": ["string", "..."],  // IDs from signals/doc chunks/WOs\n  "immediate_actions": ["string", "..."],\n  "pm_suggestions": ["string", "..."],\n  "confidence": 0.0  // 0..1\n}\n')
-        lines.append("Event JSON:")
-        lines.append(str(event))
-        lines.append("Context JSON:")
-        lines.append(str(context))
-        return "\n".join(lines)
-
-        lines.append("Task: Draft an RCA hypothesis and recommended next actions for this alarm/anomaly.")
-        lines.append(f"Event: {event}")
-        lines.append(f"Context: {context}")
-        lines.append("Output format:\\n- Title\\n- Hypothesis (2-4 bullets)\\n- Evidence to check (signals/WOs/docs)\\n- Immediate actions (1-3)\\n- Longer-term PM/design suggestions (1-2)")
-        return "\\n".join(lines)
+    def _build_prompt(self, event: Dict[str, Any], context: Dict[str, Any], prompt_selection: Dict[str, Any] | None = None) -> tuple[str, str]:
+        default_system = "You are an industrial maintenance RCA assistant. Respond with strict JSON only."
+        default_user = (
+            "Use this schema and fill every field; if unknown, produce your best estimate:\n"
+            '{{"title":"string","hypothesis":["string"],"evidence_ids":["string"],'
+            '"immediate_actions":["string"],"pm_suggestions":["string"],"confidence":0.0}}\n'
+            "Event JSON:\n{event_json}\n"
+            "Context JSON:\n{context_json}"
+        )
+        prompt_selection = prompt_selection or {}
+        system_prompt = prompt_selection.get("system_prompt") or default_system
+        user_template = prompt_selection.get("user_prompt_template") or default_user
+        prompt = user_template.format(
+            event_json=str(event),
+            context_json=str(context),
+            asset_id=event.get("asset_id"),
+            severity=event.get("severity"),
+            kind=event.get("kind"),
+        )
+        return system_prompt, prompt
 
     def _parse_structured(self, text: str) -> Dict[str, Any]:
         import json, re

--- a/maintenance_intelligence/prompts/__init__.py
+++ b/maintenance_intelligence/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""Prompt catalog and A/B selection helpers."""

--- a/maintenance_intelligence/prompts/catalog.py
+++ b/maintenance_intelligence/prompts/catalog.py
@@ -1,0 +1,287 @@
+import hashlib
+from typing import Any, Dict, List, Optional
+
+from maintenance_intelligence.context.assembler import with_pg
+from maintenance_intelligence.runner.config import Settings
+
+
+DEFAULT_PROMPTS: List[Dict[str, Any]] = [
+    {
+        "prompt_id": "rca-default-v1",
+        "route_name": "rca",
+        "version": 1,
+        "description": "Conservative RCA prompt for general industrial alarms.",
+        "intended_use": {"severity": ["medium", "high"], "asset_class": ["pump", "compressor", "generic"]},
+        "system_prompt": "You are an industrial maintenance RCA assistant. Be concise, operational, and evidence-driven.",
+        "user_prompt_template": (
+            "Return strict JSON only with title, hypothesis, evidence_ids, immediate_actions, pm_suggestions, confidence.\n"
+            "Event: {event_json}\nContext: {context_json}\n"
+            "Prefer operationally safe actions first."
+        ),
+        "active": True,
+    },
+    {
+        "prompt_id": "rca-canary-v1",
+        "route_name": "rca",
+        "version": 1,
+        "description": "Canary RCA prompt biased toward faster synthesis and actionability.",
+        "intended_use": {"severity": ["high"], "asset_class": ["pump", "compressor"]},
+        "system_prompt": "You are an industrial maintenance RCA assistant. Prioritize the most probable failure mode and immediate mitigation steps.",
+        "user_prompt_template": (
+            "Return strict JSON only with title, hypothesis, evidence_ids, immediate_actions, pm_suggestions, confidence.\n"
+            "Event: {event_json}\nContext: {context_json}\n"
+            "Bias toward the most actionable next steps for severity={severity}, kind={kind}."
+        ),
+        "active": True,
+    },
+]
+
+
+def _subject_bucket(subject_key: str) -> float:
+    digest = hashlib.sha256(subject_key.encode("utf-8")).hexdigest()
+    return int(digest[:8], 16) / 0xFFFFFFFF
+
+
+def _acceptance_rate(stats: Dict[str, Any]) -> float:
+    total = float(stats.get("total", 0) or 0)
+    accept = float(stats.get("accept", 0) or 0)
+    return (accept / total) if total > 0 else 0.0
+
+
+def choose_prompt_variant(
+    prompts_by_id: Dict[str, Dict[str, Any]],
+    route_config: Dict[str, Any],
+    subject_key: str,
+    feedback_stats: Optional[Dict[str, Dict[str, Any]]] = None,
+    subject_bucket: Optional[float] = None,
+) -> Dict[str, Any]:
+    default_prompt_id = route_config.get("default_prompt_id")
+    canary_prompt_id = route_config.get("canary_prompt_id")
+    canary_ratio = float(route_config.get("canary_ratio") or 0.0)
+    auto_rollback_triggered = False
+
+    if canary_prompt_id and route_config.get("auto_rollback_enabled") and feedback_stats:
+        min_runs = int(route_config.get("rollback_min_runs") or 20)
+        acceptance_delta = float(route_config.get("rollback_acceptance_delta") or 0.05)
+        default_stats = feedback_stats.get(default_prompt_id, {})
+        canary_stats = feedback_stats.get(canary_prompt_id, {})
+        if default_stats.get("total", 0) >= min_runs and canary_stats.get("total", 0) >= min_runs:
+            if _acceptance_rate(canary_stats) + acceptance_delta < _acceptance_rate(default_stats):
+                auto_rollback_triggered = True
+                canary_prompt_id = None
+
+    bucket = subject_bucket if subject_bucket is not None else _subject_bucket(subject_key)
+    selected_prompt_id = default_prompt_id
+    variant = "default"
+    if canary_prompt_id and canary_ratio > 0 and bucket < canary_ratio:
+        selected_prompt_id = canary_prompt_id
+        variant = "canary"
+
+    prompt = prompts_by_id[selected_prompt_id]
+    return {
+        "prompt": prompt,
+        "prompt_id": selected_prompt_id,
+        "variant": variant,
+        "route_name": route_config.get("route_name"),
+        "auto_rollback_triggered": auto_rollback_triggered,
+    }
+
+
+def _default_route_config(settings: Settings, route_name: str, org_id: str) -> Dict[str, Any]:
+    default_prompt_id = settings.prompt_defaults.get(route_name, f"{route_name}-default-v1")
+    return {
+        "config_id": f"{org_id}:{route_name}",
+        "org_id": org_id,
+        "route_name": route_name,
+        "default_prompt_id": default_prompt_id,
+        "canary_prompt_id": settings.prompt_canary_defaults.get(route_name),
+        "canary_ratio": float(settings.prompt_canary_ratio or 0.0),
+        "auto_rollback_enabled": True,
+        "rollback_min_runs": 20,
+        "rollback_acceptance_delta": 0.05,
+    }
+
+
+def seed_prompt_catalog(conn) -> None:
+    with conn, conn.cursor() as cur:
+        for prompt in DEFAULT_PROMPTS:
+            cur.execute(
+                """
+                INSERT INTO prompt_catalog (
+                    prompt_id, route_name, version, description, intended_use, system_prompt, user_prompt_template, active
+                )
+                VALUES (%s,%s,%s,%s,%s::jsonb,%s,%s,%s)
+                ON CONFLICT (prompt_id) DO NOTHING
+                """,
+                (
+                    prompt["prompt_id"],
+                    prompt["route_name"],
+                    prompt["version"],
+                    prompt["description"],
+                    __import__("json").dumps(prompt["intended_use"]),
+                    prompt["system_prompt"],
+                    prompt["user_prompt_template"],
+                    prompt["active"],
+                ),
+            )
+
+
+def list_prompts(conn, route_name: str | None = None) -> List[Dict[str, Any]]:
+    seed_prompt_catalog(conn)
+    with conn, conn.cursor() as cur:
+        if route_name:
+            cur.execute(
+                """
+                SELECT prompt_id, route_name, version, description, intended_use, system_prompt, user_prompt_template, active
+                FROM prompt_catalog
+                WHERE route_name = %s
+                ORDER BY route_name, version DESC, prompt_id
+                """,
+                (route_name,),
+            )
+        else:
+            cur.execute(
+                """
+                SELECT prompt_id, route_name, version, description, intended_use, system_prompt, user_prompt_template, active
+                FROM prompt_catalog
+                ORDER BY route_name, version DESC, prompt_id
+                """
+            )
+        rows = cur.fetchall() or []
+    return [
+        {
+            "prompt_id": row[0],
+            "route_name": row[1],
+            "version": row[2],
+            "description": row[3],
+            "intended_use": row[4] or {},
+            "system_prompt": row[5],
+            "user_prompt_template": row[6],
+            "active": row[7],
+        }
+        for row in rows
+    ]
+
+
+def load_route_config(conn, settings: Settings, route_name: str, org_id: str) -> Dict[str, Any]:
+    seed_prompt_catalog(conn)
+    config_ids = [f"{org_id}:{route_name}", f"global:{route_name}"]
+    with conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT config_id, org_id, route_name, default_prompt_id, canary_prompt_id, canary_ratio,
+                   auto_rollback_enabled, rollback_min_runs, rollback_acceptance_delta
+            FROM prompt_route_configs
+            WHERE config_id = ANY(%s)
+            ORDER BY CASE WHEN config_id = %s THEN 0 ELSE 1 END
+            LIMIT 1
+            """,
+            (config_ids, f"{org_id}:{route_name}"),
+        )
+        row = cur.fetchone()
+    if not row:
+        return _default_route_config(settings, route_name, org_id)
+    return {
+        "config_id": row[0],
+        "org_id": row[1],
+        "route_name": row[2],
+        "default_prompt_id": row[3],
+        "canary_prompt_id": row[4],
+        "canary_ratio": float(row[5] or 0.0),
+        "auto_rollback_enabled": bool(row[6]),
+        "rollback_min_runs": int(row[7] or 20),
+        "rollback_acceptance_delta": float(row[8] or 0.05),
+    }
+
+
+def save_route_config(conn, route_name: str, org_id: Optional[str], payload: Dict[str, Any]) -> Dict[str, Any]:
+    seed_prompt_catalog(conn)
+    effective_org = org_id or "global"
+    config_id = f"{effective_org}:{route_name}"
+    with conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO prompt_route_configs (
+                config_id, org_id, route_name, default_prompt_id, canary_prompt_id, canary_ratio,
+                auto_rollback_enabled, rollback_min_runs, rollback_acceptance_delta
+            )
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            ON CONFLICT (config_id) DO UPDATE SET
+                default_prompt_id = EXCLUDED.default_prompt_id,
+                canary_prompt_id = EXCLUDED.canary_prompt_id,
+                canary_ratio = EXCLUDED.canary_ratio,
+                auto_rollback_enabled = EXCLUDED.auto_rollback_enabled,
+                rollback_min_runs = EXCLUDED.rollback_min_runs,
+                rollback_acceptance_delta = EXCLUDED.rollback_acceptance_delta,
+                updated_at = NOW()
+            """,
+            (
+                config_id,
+                None if effective_org == "global" else effective_org,
+                route_name,
+                payload["default_prompt_id"],
+                payload.get("canary_prompt_id"),
+                float(payload.get("canary_ratio") or 0.0),
+                bool(payload.get("auto_rollback_enabled", True)),
+                int(payload.get("rollback_min_runs") or 20),
+                float(payload.get("rollback_acceptance_delta") or 0.05),
+            ),
+        )
+    return {
+        "config_id": config_id,
+        "org_id": None if effective_org == "global" else effective_org,
+        "route_name": route_name,
+        "default_prompt_id": payload["default_prompt_id"],
+        "canary_prompt_id": payload.get("canary_prompt_id"),
+        "canary_ratio": float(payload.get("canary_ratio") or 0.0),
+        "auto_rollback_enabled": bool(payload.get("auto_rollback_enabled", True)),
+        "rollback_min_runs": int(payload.get("rollback_min_runs") or 20),
+        "rollback_acceptance_delta": float(payload.get("rollback_acceptance_delta") or 0.05),
+    }
+
+
+def prompt_feedback_stats(conn, org_id: str, prompt_ids: List[str]) -> Dict[str, Dict[str, Any]]:
+    if not prompt_ids:
+        return {}
+    with conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT prompt_id,
+                   COUNT(*) AS total_count,
+                   COUNT(*) FILTER (WHERE action = 'accept') AS accept_count
+            FROM rca_feedback
+            WHERE org_id = %s AND prompt_id = ANY(%s)
+            GROUP BY prompt_id
+            """,
+            (org_id, prompt_ids),
+        )
+        rows = cur.fetchall() or []
+    return {row[0]: {"total": int(row[1] or 0), "accept": int(row[2] or 0)} for row in rows}
+
+
+def resolve_prompt_for_route(
+    route_name: str,
+    org_id: str,
+    subject_key: str,
+    settings: Optional[Settings] = None,
+) -> Dict[str, Any]:
+    settings = settings or Settings()
+    fallback_prompts = {prompt["prompt_id"]: prompt for prompt in DEFAULT_PROMPTS if prompt["route_name"] == route_name}
+    fallback_config = _default_route_config(settings, route_name, org_id)
+    try:
+        conn = with_pg(settings.pg_dsn)
+    except Exception:
+        return choose_prompt_variant(fallback_prompts, fallback_config, subject_key)
+
+    try:
+        prompts = list_prompts(conn, route_name=route_name)
+        prompts_by_id = {prompt["prompt_id"]: prompt for prompt in prompts}
+        route_config = load_route_config(conn, settings, route_name, org_id)
+        stats = prompt_feedback_stats(
+            conn,
+            org_id,
+            [prompt_id for prompt_id in [route_config.get("default_prompt_id"), route_config.get("canary_prompt_id")] if prompt_id],
+        )
+        return choose_prompt_variant(prompts_by_id, route_config, subject_key, feedback_stats=stats)
+    finally:
+        conn.close()

--- a/maintenance_intelligence/runner/config.py
+++ b/maintenance_intelligence/runner/config.py
@@ -19,6 +19,9 @@ class Settings(BaseSettings):
     auth_mode: str = Field(default="none", alias="MI_AUTH_MODE")
     api_keys_raw: str = Field(default="{}", alias="MI_API_KEYS")
     kafka_tenant_mode: str = Field(default="message", alias="MI_KAFKA_TENANT_MODE")
+    prompt_defaults_raw: str = Field(default='{"rca":"rca-default-v1"}', alias="MI_PROMPT_DEFAULTS")
+    prompt_canary_defaults_raw: str = Field(default='{"rca":"rca-canary-v1"}', alias="MI_PROMPT_CANARY_DEFAULTS")
+    prompt_canary_ratio: float = Field(default=0.1, alias="MI_PROMPT_CANARY_RATIO")
     genai_model: str = Field(default="gpt-4.1")
     genai_timeout_s: int = Field(default=25)
     run_summary_dir: str = Field(default="outputs")
@@ -36,6 +39,22 @@ class Settings(BaseSettings):
     def api_keys(self) -> Dict[str, Dict[str, Any]]:
         try:
             data = json.loads(self.api_keys_raw or "{}")
+        except json.JSONDecodeError:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    @property
+    def prompt_defaults(self) -> Dict[str, str]:
+        try:
+            data = json.loads(self.prompt_defaults_raw or "{}")
+        except json.JSONDecodeError:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    @property
+    def prompt_canary_defaults(self) -> Dict[str, str]:
+        try:
+            data = json.loads(self.prompt_canary_defaults_raw or "{}")
         except json.JSONDecodeError:
             return {}
         return data if isinstance(data, dict) else {}

--- a/maintenance_intelligence/runner/summaries.py
+++ b/maintenance_intelligence/runner/summaries.py
@@ -5,6 +5,6 @@ def write_run_summary(dir_path: str, run_id: str, payload: dict) -> str:
     date_dir = Path(dir_path) / dt.datetime.utcnow().strftime("%Y-%m-%d")
     date_dir.mkdir(parents=True, exist_ok=True)
     out = date_dir / f"{run_id}.json"
-    with out.open("w") as f:
+    with out.open("w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2)
     return str(out)

--- a/maintenance_intelligence/services/rca_agent.py
+++ b/maintenance_intelligence/services/rca_agent.py
@@ -5,10 +5,11 @@ from loguru import logger
 from maintenance_intelligence.multitenancy import consumer_topics, event_in_scope, scoped_topic
 from maintenance_intelligence.runner.config import Settings
 from maintenance_intelligence.genai.gateway import GenAIGateway
+from maintenance_intelligence.prompts.catalog import resolve_prompt_for_route
 from maintenance_intelligence.runner.summaries import write_run_summary
 from maintenance_intelligence.context.assembler import get_event_context
 import backoff
-from maintenance_intelligence.api.metrics import recommendations_created_total, rca_runs_total, rca_failures_total, rca_duration_seconds
+from maintenance_intelligence.api.metrics import recommendations_created_total, rca_runs_total, rca_runs_by_prompt_total, rca_failures_total, rca_duration_seconds
 
 @backoff.on_exception(backoff.expo, KafkaError, max_tries=5, max_time=60)
 def create_kafka_consumer(kafka_bootstrap: str, settings: Settings):
@@ -39,6 +40,11 @@ def send_recommendation(producer, recommendation, settings: Settings):
     """Send recommendation with retry logic."""
     producer.send(scoped_topic("canonical.recommendation.created", settings, recommendation.get("org_id")), recommendation)
     producer.flush()
+
+
+def _record_prompt_run_metrics(prompt_id: str, variant: str, route_name: str = "rca", service: str = "rca_agent"):
+    rca_runs_total.labels(service=service).inc()
+    rca_runs_by_prompt_total.labels(service=service, route=route_name, prompt_id=prompt_id, variant=variant).inc()
 
 def rca_agent(kafka_bootstrap: str = None):
     logger.info({"event": "rca_agent.start"})
@@ -84,16 +90,49 @@ def rca_agent(kafka_bootstrap: str = None):
             try:
                 # Assemble MVP context
                 ctx = get_event_context(evt, settings, org_id=evt.get("org_id"))
+                prompt_selection = resolve_prompt_for_route(
+                    route_name="rca",
+                    org_id=evt.get("org_id") or settings.default_org,
+                    subject_key=evt.get("event_id") or evt.get("asset_id") or str(uuid.uuid4()),
+                    settings=settings,
+                )
+                prompt_meta = {
+                    "prompt_id": prompt_selection["prompt_id"],
+                    "variant": prompt_selection["variant"],
+                    "route_name": prompt_selection["route_name"],
+                    "auto_rollback_triggered": prompt_selection.get("auto_rollback_triggered", False),
+                }
 
                 if gateway:
-                    g = gateway.call_rca(evt, ctx)
+                    try:
+                        g = gateway.call_rca(evt, ctx, prompt_selection=prompt_selection["prompt"])
+                    except TypeError:
+                        g = gateway.call_rca(evt, ctx)
                     structured = g.get("structured") or {}
                     rationale = "\n".join(structured.get("hypothesis", [])[:4]) or g.get("text", "No output")
-                    model_meta = {"name": "openai", "version": g.get("model_version"), "tokens": g.get("tokens"), "latency_ms": g.get("latency_ms"), "confidence": structured.get("confidence", 0.5)}
+                    model_meta = {
+                        "name": "openai",
+                        "version": g.get("model_version"),
+                        "tokens": g.get("tokens"),
+                        "latency_ms": g.get("latency_ms"),
+                        "confidence": structured.get("confidence", 0.5),
+                        "prompt_id": prompt_meta["prompt_id"],
+                        "prompt_variant": prompt_meta["variant"],
+                        "prompt_route": prompt_meta["route_name"],
+                    }
                 else:
                     rationale = "Stub RCA (no OPENAI_API_KEY). Replace with GenAI output once key is set."
                     structured = {"title":"RCA Draft","hypothesis":[rationale],"evidence_ids":[],"immediate_actions":[],"pm_suggestions":[],"confidence":0.3}
-                    model_meta = {"name": "openai", "version": "unset", "tokens": None, "latency_ms": None, "confidence": structured.get("confidence", 0.3)}
+                    model_meta = {
+                        "name": "openai",
+                        "version": "unset",
+                        "tokens": None,
+                        "latency_ms": None,
+                        "confidence": structured.get("confidence", 0.3),
+                        "prompt_id": prompt_meta["prompt_id"],
+                        "prompt_variant": prompt_meta["variant"],
+                        "prompt_route": prompt_meta["route_name"],
+                    }
 
                 rec_id = str(uuid.uuid4())
                 doc_chunk_ids = [d.get("chunk_id") for d in ctx.get("doc_chunks", []) if isinstance(d, dict)]
@@ -118,6 +157,7 @@ def rca_agent(kafka_bootstrap: str = None):
                         "wo_titles_count": len(ctx.get("last_wo_titles", [])),
                         "doc_chunk_ids": doc_chunk_ids,
                     },
+                    "prompt": prompt_meta,
                 }
 
                 send_recommendation(prod, out, settings)
@@ -129,13 +169,14 @@ def rca_agent(kafka_bootstrap: str = None):
                     "recommendation_id": rec_id,
                     "event_id": evt.get("event_id"),
                     "model": model_meta,
+                    "prompt": prompt_meta,
                     "structured": structured,
                     "context_meta": out.get("context_meta", {}),
                 })
 
                 logger.info({"event":"rca.recommendation.created","id":rec_id,"model":model_meta,"ctx":out.get("context_meta")})
                 try:
-                    rca_runs_total.labels(service="rca_agent").inc()
+                    _record_prompt_run_metrics(prompt_meta["prompt_id"], prompt_meta["variant"], route_name=prompt_meta["route_name"])
                     rca_duration_seconds.labels(service="rca_agent").observe(max(0.0, time.time() - _t0))
                     recommendations_created_total.labels(service="rca_agent").inc()
                 except Exception:

--- a/tests/test_prompt_api.py
+++ b/tests/test_prompt_api.py
@@ -1,0 +1,109 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from maintenance_intelligence.api.main import app
+from maintenance_intelligence.api.metrics import prompt_feedback_total
+from maintenance_intelligence.api import feedback as feedback_api
+from maintenance_intelligence.api import prompts as prompts_api
+
+
+def test_prompt_api_list_and_admin_update(monkeypatch):
+    monkeypatch.setenv("MI_AUTH_MODE", "api_key")
+    monkeypatch.setenv(
+        "MI_API_KEYS",
+        json.dumps(
+            {
+                "viewer-key": {"org_id": "ORG-1", "role": "viewer"},
+                "admin-key": {"org_id": "ORG-1", "role": "admin"},
+            }
+        ),
+    )
+
+    class FakeConn:
+        def close(self):
+            return None
+
+    monkeypatch.setattr(prompts_api, "with_pg", lambda _dsn: FakeConn())
+    monkeypatch.setattr(
+        prompts_api,
+        "list_prompts",
+        lambda conn, route_name=None: [{"prompt_id": "rca-default-v1", "route_name": route_name or "rca"}],
+    )
+    monkeypatch.setattr(
+        prompts_api,
+        "load_route_config",
+        lambda conn, settings, route_name, org_id: {"route_name": route_name, "default_prompt_id": "rca-default-v1", "org_id": org_id},
+    )
+    monkeypatch.setattr(
+        prompts_api,
+        "save_route_config",
+        lambda conn, route_name, org_id, payload: {"route_name": route_name, "org_id": org_id, **payload},
+    )
+
+    client = TestClient(app)
+    listed = client.get("/api/v1/prompts?route=rca", headers={"X-API-Key": "viewer-key"})
+    updated = client.put(
+        "/api/v1/prompts/routes/rca",
+        json={"default_prompt_id": "rca-default-v1", "canary_prompt_id": "rca-canary-v1", "canary_ratio": 0.1},
+        headers={"X-API-Key": "admin-key"},
+    )
+    denied = client.put(
+        "/api/v1/prompts/routes/rca",
+        json={"default_prompt_id": "rca-default-v1"},
+        headers={"X-API-Key": "viewer-key"},
+    )
+
+    assert listed.status_code == 200
+    assert listed.json()["prompts"][0]["prompt_id"] == "rca-default-v1"
+    assert updated.status_code == 200
+    assert updated.json()["config"]["canary_prompt_id"] == "rca-canary-v1"
+    assert denied.status_code == 403
+
+
+def test_feedback_prompt_metric_increments(monkeypatch):
+    monkeypatch.setenv("MI_AUTH_MODE", "api_key")
+    monkeypatch.setenv("MI_API_KEYS", json.dumps({"operator-key": {"org_id": "ORG-1", "role": "operator"}}))
+
+    class FakeCursor:
+        def execute(self, *_args, **_kwargs):
+            return None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeConn:
+        def cursor(self, *args, **kwargs):
+            return FakeCursor()
+
+        def close(self):
+            return None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(feedback_api, "with_pg", lambda _dsn: FakeConn())
+
+    client = TestClient(app)
+    before = prompt_feedback_total.labels(route="rca", prompt_id="rca-default-v1", action="accept")._value.get()
+    response = client.post(
+        "/api/v1/rca/feedback",
+        json={
+            "run_id": "RUN-1",
+            "recommendation_id": "REC-1",
+            "action": "accept",
+            "prompt_id": "rca-default-v1",
+            "prompt_route": "rca",
+        },
+        headers={"X-API-Key": "operator-key"},
+    )
+    after = prompt_feedback_total.labels(route="rca", prompt_id="rca-default-v1", action="accept")._value.get()
+
+    assert response.status_code == 200
+    assert after == before + 1

--- a/tests/test_prompt_catalog.py
+++ b/tests/test_prompt_catalog.py
@@ -1,0 +1,49 @@
+from maintenance_intelligence.prompts.catalog import choose_prompt_variant
+
+
+def test_choose_prompt_variant_canary_split():
+    prompts = {
+        "rca-default-v1": {"prompt_id": "rca-default-v1"},
+        "rca-canary-v1": {"prompt_id": "rca-canary-v1"},
+    }
+    route_config = {
+        "route_name": "rca",
+        "default_prompt_id": "rca-default-v1",
+        "canary_prompt_id": "rca-canary-v1",
+        "canary_ratio": 0.1,
+        "auto_rollback_enabled": False,
+    }
+
+    canary = choose_prompt_variant(prompts, route_config, "evt-1", subject_bucket=0.05)
+    default = choose_prompt_variant(prompts, route_config, "evt-2", subject_bucket=0.55)
+
+    assert canary["prompt_id"] == "rca-canary-v1"
+    assert canary["variant"] == "canary"
+    assert default["prompt_id"] == "rca-default-v1"
+    assert default["variant"] == "default"
+
+
+def test_choose_prompt_variant_auto_rolls_back_underperforming_canary():
+    prompts = {
+        "rca-default-v1": {"prompt_id": "rca-default-v1"},
+        "rca-canary-v1": {"prompt_id": "rca-canary-v1"},
+    }
+    route_config = {
+        "route_name": "rca",
+        "default_prompt_id": "rca-default-v1",
+        "canary_prompt_id": "rca-canary-v1",
+        "canary_ratio": 0.5,
+        "auto_rollback_enabled": True,
+        "rollback_min_runs": 5,
+        "rollback_acceptance_delta": 0.05,
+    }
+    stats = {
+        "rca-default-v1": {"total": 10, "accept": 8},
+        "rca-canary-v1": {"total": 10, "accept": 2},
+    }
+
+    selected = choose_prompt_variant(prompts, route_config, "evt-3", feedback_stats=stats, subject_bucket=0.01)
+
+    assert selected["prompt_id"] == "rca-default-v1"
+    assert selected["variant"] == "default"
+    assert selected["auto_rollback_triggered"] is True

--- a/tests/test_prompt_routing.py
+++ b/tests/test_prompt_routing.py
@@ -1,0 +1,72 @@
+import json
+
+from maintenance_intelligence.api.metrics import rca_runs_by_prompt_total
+from maintenance_intelligence.services import rca_agent as rca_mod
+
+
+def test_rca_agent_records_prompt_metadata_and_metric(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+
+    class FakeCons:
+        def __iter__(self):
+            return iter([type("M", (), {"value": {"org_id": "ORG-1", "asset_id": "A1", "kind": "alarm", "event_id": "E1"}})()])
+
+        def close(self):
+            return None
+
+    class FakeProd:
+        def close(self, timeout=10):
+            return None
+
+    class FakeGW:
+        def __init__(self, **kwargs):
+            pass
+
+        def call_rca(self, event, context, prompt_selection=None):
+            return {
+                "text": "ok",
+                "model_version": "gpt-4.1",
+                "tokens": 42,
+                "latency_ms": 12,
+                "structured": {
+                    "title": "Seal wear on pump",
+                    "hypothesis": ["Bearing wear"],
+                    "evidence_ids": ["DOC-1"],
+                    "immediate_actions": ["Check bearing temp"],
+                    "pm_suggestions": ["Increase lube cycle"],
+                    "confidence": 0.82,
+                },
+            }
+
+    written = {}
+
+    monkeypatch.setattr(rca_mod, "create_kafka_consumer", lambda *_a, **_k: FakeCons())
+    monkeypatch.setattr(rca_mod, "create_kafka_producer", lambda *_a, **_k: FakeProd())
+    monkeypatch.setattr(rca_mod, "GenAIGateway", FakeGW)
+    monkeypatch.setattr(rca_mod, "get_event_context", lambda evt, settings, org_id=None: {"doc_chunks": [{"chunk_id": "DOC-1"}], "recent_signals": []})
+    monkeypatch.setattr(
+        rca_mod,
+        "resolve_prompt_for_route",
+        lambda route_name, org_id, subject_key, settings=None: {
+            "prompt": {"prompt_id": "rca-canary-v1", "system_prompt": "sys", "user_prompt_template": "Event {event_json}"},
+            "prompt_id": "rca-canary-v1",
+            "variant": "canary",
+            "route_name": "rca",
+            "auto_rollback_triggered": False,
+        },
+    )
+    monkeypatch.setattr(rca_mod, "send_recommendation", lambda *args, **kwargs: None)
+
+    def fake_write(dir_path, run_id, payload):
+        written["payload"] = payload
+        return str(tmp_path / "summary.json")
+
+    monkeypatch.setattr(rca_mod, "write_run_summary", fake_write)
+
+    before = rca_runs_by_prompt_total.labels(service="rca_agent", route="rca", prompt_id="rca-canary-v1", variant="canary")._value.get()
+    rca_mod.rca_agent("kafka:9092")
+    after = rca_runs_by_prompt_total.labels(service="rca_agent", route="rca", prompt_id="rca-canary-v1", variant="canary")._value.get()
+
+    assert after == before + 1
+    assert written["payload"]["prompt"]["prompt_id"] == "rca-canary-v1"
+    assert written["payload"]["model"]["prompt_variant"] == "canary"


### PR DESCRIPTION
## Summary
- add a prompt catalog with built-in versions, route config storage, deterministic canary selection, and optional rollback based on prompt-linked feedback
- thread prompt selection through the RCA gateway and agent so prompt metadata is recorded in summaries, model metadata, and new per-prompt metrics
- add prompt list/admin APIs, schema migrations, config/docs updates, and focused tests for routing, metrics, and feedback linkage

## Validation
- /home/codespace/.python/current/bin/python -m py_compile maintenance_intelligence/prompts/catalog.py maintenance_intelligence/api/prompts.py maintenance_intelligence/genai/gateway.py maintenance_intelligence/services/rca_agent.py maintenance_intelligence/api/feedback.py maintenance_intelligence/api/main.py maintenance_intelligence/db/alembic/versions/004_prompt_catalog.py
- /home/codespace/.python/current/bin/python -m pytest -q tests/test_prompt_catalog.py tests/test_prompt_api.py tests/test_prompt_routing.py tests/test_agent_structured_mock.py tests/test_metrics_endpoint.py
- /home/codespace/.python/current/bin/python -m pytest -q tests/test_outcomes_shape.py tests/test_api_health.py