### PR TITLE
Add RCA cost and latency dashboards v2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,7 @@ MI_KAFKA_TENANT_MODE=message
 MI_PROMPT_DEFAULTS={"rca":"rca-default-v1"}
 MI_PROMPT_CANARY_DEFAULTS={"rca":"rca-canary-v1"}
 MI_PROMPT_CANARY_RATIO=0.1
+
+# RCA Cost / Latency Dashboards v2
+MI_RCA_MODEL_RATES={"gpt-4.1":{"per_1k_tokens_usd":0.01},"unset":{"per_1k_tokens_usd":0.0}}
+MI_RCA_BUDGET_CAPS_USD={"daily":25.0,"weekly":100.0}

--- a/README.md
+++ b/README.md
@@ -183,3 +183,12 @@ Notes:
 - `MI_PROMPT_DEFAULTS` and `MI_PROMPT_CANARY_DEFAULTS` provide config-backed fallbacks when no DB override exists.
 - `MI_PROMPT_CANARY_RATIO` controls the default canary split; the RCA agent records `prompt_id` and variant in run summaries and recommendation model metadata.
 - Feedback can carry `prompt_id` and `prompt_route`, enabling prompt quality tracking via `prompt_feedback_total` and auto-rollback decisions.
+
+## Cost and Latency Dashboards v2
+
+- RCA runs now export `rca_cost_usd_total{model,prompt_id}` using a token-based estimate derived from `MI_RCA_MODEL_RATES`.
+- Model latency is exported via `rca_latency_seconds{service,model,prompt_id}` while the existing `rca_duration_seconds{service}` still tracks full agent runtime.
+- Budget caps are exposed via `rca_budget_cap_usd{window}` using `MI_RCA_BUDGET_CAPS_USD` for daily and weekly utilization panels.
+- Prompt acceptance rate is derived from `prompt_feedback_total{route,prompt_id,action}` in PromQL rather than stored as a separate gauge.
+- RCA run summaries now persist `estimated_cost_usd` alongside tokens and latency for per-run auditability.
+- Dashboard and alert assets live under `monitoring/grafana/rca_observability_v2.dashboard.json` and `monitoring/prometheus/rca_observability_v2_alerts.yml`.

--- a/maintenance_intelligence/api/metrics.py
+++ b/maintenance_intelligence/api/metrics.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Response
-from prometheus_client import CollectorRegistry, Counter, Histogram, Gauge, generate_latest, CONTENT_TYPE_LATEST
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Counter, Gauge, Histogram, generate_latest
 
 router = APIRouter()
 
@@ -10,6 +10,19 @@ REGISTRY = CollectorRegistry(auto_describe=True)
 rca_runs_total = Counter("rca_runs_total", "Total RCA runs", ["service"], registry=REGISTRY)
 rca_failures_total = Counter("rca_failures_total", "Total RCA run failures", ["service"], registry=REGISTRY)
 rca_duration_seconds = Histogram("rca_duration_seconds", "RCA run duration (seconds)", ["service"], registry=REGISTRY, buckets=(0.1,0.3,1,3,10,30,60,120))
+rca_latency_seconds = Histogram(
+    "rca_latency_seconds",
+    "RCA model latency (seconds) by model and prompt",
+    ["service", "model", "prompt_id"],
+    registry=REGISTRY,
+    buckets=(0.1, 0.3, 1, 3, 10, 30, 60, 120),
+)
+rca_cost_usd_total = Counter(
+    "rca_cost_usd_total",
+    "Estimated RCA spend in USD by model and prompt",
+    ["model", "prompt_id"],
+    registry=REGISTRY,
+)
 
 events_ingested_total = Counter("events_ingested_total", "Total events ingested", ["service"], registry=REGISTRY)
 recommendations_created_total = Counter("recommendations_created_total", "Total recommendations created", ["service"], registry=REGISTRY)
@@ -29,8 +42,28 @@ prompt_feedback_total = Counter(
 
 # Kafka lag gauge (optional; set by health checks if desired)
 kafka_consume_lag = Gauge("kafka_consume_lag", "Kafka consumer group lag (total)", ["group"], registry=REGISTRY)
+rca_budget_cap_usd = Gauge(
+    "rca_budget_cap_usd",
+    "Configured RCA spend cap in USD by budget window",
+    ["window"],
+    registry=REGISTRY,
+)
+
+
+def publish_budget_caps(budget_caps: dict[str, float]):
+    for window, amount in (budget_caps or {}).items():
+        try:
+            rca_budget_cap_usd.labels(window=window).set(max(0.0, float(amount)))
+        except (TypeError, ValueError):
+            continue
 
 @router.get("/metrics")
 def metrics():
+    try:
+        from maintenance_intelligence.runner.config import Settings
+
+        publish_budget_caps(Settings().rca_budget_caps_usd)
+    except Exception:
+        pass
     data = generate_latest(REGISTRY)
     return Response(content=data, media_type=CONTENT_TYPE_LATEST)

--- a/maintenance_intelligence/runner/config.py
+++ b/maintenance_intelligence/runner/config.py
@@ -22,6 +22,11 @@ class Settings(BaseSettings):
     prompt_defaults_raw: str = Field(default='{"rca":"rca-default-v1"}', alias="MI_PROMPT_DEFAULTS")
     prompt_canary_defaults_raw: str = Field(default='{"rca":"rca-canary-v1"}', alias="MI_PROMPT_CANARY_DEFAULTS")
     prompt_canary_ratio: float = Field(default=0.1, alias="MI_PROMPT_CANARY_RATIO")
+    rca_model_rates_raw: str = Field(
+        default='{"gpt-4.1":{"per_1k_tokens_usd":0.01},"unset":{"per_1k_tokens_usd":0.0}}',
+        alias="MI_RCA_MODEL_RATES",
+    )
+    rca_budget_caps_usd_raw: str = Field(default='{"daily":25.0,"weekly":100.0}', alias="MI_RCA_BUDGET_CAPS_USD")
     genai_model: str = Field(default="gpt-4.1")
     genai_timeout_s: int = Field(default=25)
     run_summary_dir: str = Field(default="outputs")
@@ -58,6 +63,37 @@ class Settings(BaseSettings):
         except json.JSONDecodeError:
             return {}
         return data if isinstance(data, dict) else {}
+
+    @property
+    def rca_model_rates(self) -> Dict[str, float]:
+        try:
+            data = json.loads(self.rca_model_rates_raw or "{}")
+        except json.JSONDecodeError:
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        parsed: Dict[str, float] = {}
+        for model_name, raw_value in data.items():
+            if isinstance(raw_value, (int, float)):
+                parsed[model_name] = float(raw_value)
+                continue
+            if isinstance(raw_value, dict) and isinstance(raw_value.get("per_1k_tokens_usd"), (int, float)):
+                parsed[model_name] = float(raw_value["per_1k_tokens_usd"])
+        return parsed
+
+    @property
+    def rca_budget_caps_usd(self) -> Dict[str, float]:
+        try:
+            data = json.loads(self.rca_budget_caps_usd_raw or "{}")
+        except json.JSONDecodeError:
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        parsed: Dict[str, float] = {}
+        for window, raw_value in data.items():
+            if isinstance(raw_value, (int, float)):
+                parsed[window] = float(raw_value)
+        return parsed
 
     class Config:
         env_prefix = "MI_"

--- a/maintenance_intelligence/services/rca_agent.py
+++ b/maintenance_intelligence/services/rca_agent.py
@@ -1,4 +1,9 @@
-import os, json, uuid, datetime as dt, signal, sys
+import datetime as dt
+import json
+import os
+import signal
+import sys
+import uuid
 from kafka import KafkaConsumer, KafkaProducer
 from kafka.errors import KafkaError
 from loguru import logger
@@ -9,7 +14,16 @@ from maintenance_intelligence.prompts.catalog import resolve_prompt_for_route
 from maintenance_intelligence.runner.summaries import write_run_summary
 from maintenance_intelligence.context.assembler import get_event_context
 import backoff
-from maintenance_intelligence.api.metrics import recommendations_created_total, rca_runs_total, rca_runs_by_prompt_total, rca_failures_total, rca_duration_seconds
+from maintenance_intelligence.api.metrics import (
+    publish_budget_caps,
+    recommendations_created_total,
+    rca_cost_usd_total,
+    rca_duration_seconds,
+    rca_failures_total,
+    rca_latency_seconds,
+    rca_runs_by_prompt_total,
+    rca_runs_total,
+)
 
 @backoff.on_exception(backoff.expo, KafkaError, max_tries=5, max_time=60)
 def create_kafka_consumer(kafka_bootstrap: str, settings: Settings):
@@ -42,9 +56,41 @@ def send_recommendation(producer, recommendation, settings: Settings):
     producer.flush()
 
 
-def _record_prompt_run_metrics(prompt_id: str, variant: str, route_name: str = "rca", service: str = "rca_agent"):
+def _resolve_model_rate(model_name: str | None, settings: Settings) -> float:
+    model_name = model_name or "unset"
+    configured_rates = settings.rca_model_rates
+    if model_name in configured_rates:
+        return configured_rates[model_name]
+    for configured_model, rate in configured_rates.items():
+        if model_name.startswith(configured_model):
+            return rate
+    return configured_rates.get("default", 0.0)
+
+
+def _estimate_cost_usd(tokens: int | None, model_name: str | None, settings: Settings) -> float:
+    if not tokens or tokens <= 0:
+        return 0.0
+    estimated = (float(tokens) / 1000.0) * _resolve_model_rate(model_name, settings)
+    return round(max(0.0, estimated), 6)
+
+
+def _record_prompt_run_metrics(
+    prompt_id: str,
+    variant: str,
+    model_name: str,
+    latency_ms: int | None,
+    estimated_cost_usd: float,
+    route_name: str = "rca",
+    service: str = "rca_agent",
+):
+    prompt_label = prompt_id or "unknown"
+    model_label = model_name or "unknown"
     rca_runs_total.labels(service=service).inc()
-    rca_runs_by_prompt_total.labels(service=service, route=route_name, prompt_id=prompt_id, variant=variant).inc()
+    rca_runs_by_prompt_total.labels(service=service, route=route_name, prompt_id=prompt_label, variant=variant).inc()
+    if latency_ms is not None:
+        rca_latency_seconds.labels(service=service, model=model_label, prompt_id=prompt_label).observe(max(0.0, latency_ms / 1000.0))
+    if estimated_cost_usd > 0:
+        rca_cost_usd_total.labels(model=model_label, prompt_id=prompt_label).inc(estimated_cost_usd)
 
 def rca_agent(kafka_bootstrap: str = None):
     logger.info({"event": "rca_agent.start"})
@@ -61,6 +107,7 @@ def rca_agent(kafka_bootstrap: str = None):
     signal.signal(signal.SIGTERM, signal_handler)
 
     settings = Settings()
+    publish_budget_caps(settings.rca_budget_caps_usd)
     kafka_bootstrap = kafka_bootstrap or settings.kafka_bootstrap
 
     cons = None
@@ -110,11 +157,13 @@ def rca_agent(kafka_bootstrap: str = None):
                         g = gateway.call_rca(evt, ctx)
                     structured = g.get("structured") or {}
                     rationale = "\n".join(structured.get("hypothesis", [])[:4]) or g.get("text", "No output")
+                    estimated_cost_usd = _estimate_cost_usd(g.get("tokens"), g.get("model_version"), settings)
                     model_meta = {
                         "name": "openai",
                         "version": g.get("model_version"),
                         "tokens": g.get("tokens"),
                         "latency_ms": g.get("latency_ms"),
+                        "estimated_cost_usd": estimated_cost_usd,
                         "confidence": structured.get("confidence", 0.5),
                         "prompt_id": prompt_meta["prompt_id"],
                         "prompt_variant": prompt_meta["variant"],
@@ -123,11 +172,13 @@ def rca_agent(kafka_bootstrap: str = None):
                 else:
                     rationale = "Stub RCA (no OPENAI_API_KEY). Replace with GenAI output once key is set."
                     structured = {"title":"RCA Draft","hypothesis":[rationale],"evidence_ids":[],"immediate_actions":[],"pm_suggestions":[],"confidence":0.3}
+                    estimated_cost_usd = 0.0
                     model_meta = {
                         "name": "openai",
                         "version": "unset",
                         "tokens": None,
                         "latency_ms": None,
+                        "estimated_cost_usd": estimated_cost_usd,
                         "confidence": structured.get("confidence", 0.3),
                         "prompt_id": prompt_meta["prompt_id"],
                         "prompt_variant": prompt_meta["variant"],
@@ -171,12 +222,24 @@ def rca_agent(kafka_bootstrap: str = None):
                     "model": model_meta,
                     "prompt": prompt_meta,
                     "structured": structured,
+                    "metrics": {
+                        "estimated_cost_usd": estimated_cost_usd,
+                        "latency_ms": model_meta.get("latency_ms"),
+                        "tokens": model_meta.get("tokens"),
+                    },
                     "context_meta": out.get("context_meta", {}),
                 })
 
                 logger.info({"event":"rca.recommendation.created","id":rec_id,"model":model_meta,"ctx":out.get("context_meta")})
                 try:
-                    _record_prompt_run_metrics(prompt_meta["prompt_id"], prompt_meta["variant"], route_name=prompt_meta["route_name"])
+                    _record_prompt_run_metrics(
+                        prompt_meta["prompt_id"],
+                        prompt_meta["variant"],
+                        model_meta.get("version") or "unset",
+                        model_meta.get("latency_ms"),
+                        estimated_cost_usd,
+                        route_name=prompt_meta["route_name"],
+                    )
                     rca_duration_seconds.labels(service="rca_agent").observe(max(0.0, time.time() - _t0))
                     recommendations_created_total.labels(service="rca_agent").inc()
                 except Exception:

--- a/monitoring/grafana/rca_observability_v2.dashboard.json
+++ b/monitoring/grafana/rca_observability_v2.dashboard.json
@@ -1,0 +1,486 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rca_cost_usd_total[1d])) / clamp_min(max(rca_budget_cap_usd{window=\"daily\"}), 0.0001)",
+          "legendFormat": "daily utilization",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Daily Budget Utilization",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (model, prompt_id) (increase(rca_cost_usd_total[1d]))",
+          "legendFormat": "{{model}} / {{prompt_id}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (model, prompt_id) (increase(rca_cost_usd_total[7d]))",
+          "legendFormat": "7d {{model}} / {{prompt_id}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Cost Per Model / Prompt",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 15,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (model) (increase(rca_cost_usd_total[7d]))",
+          "legendFormat": "{{model}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Weekly Spend Share by Model",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (le, model, prompt_id) (rate(rca_latency_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{model}} / {{prompt_id}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, model, prompt_id) (rate(rca_latency_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{model}} / {{prompt_id}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Latency p50 / p95 by Model / Prompt",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (prompt_id) (increase(prompt_feedback_total{action=\"accept\"}[7d])) / clamp_min(sum by (prompt_id) (increase(prompt_feedback_total[7d])), 1)",
+          "legendFormat": "{{prompt_id}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Prompt Acceptance Rate (7d)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rca_cost_usd_total[1h]))",
+          "legendFormat": "last 1h",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rca_cost_usd_total[24h])) / 24",
+          "legendFormat": "rolling hourly baseline",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Spend Spike vs Rolling Baseline",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, model) (rate(rca_latency_seconds_bucket[15m])))",
+          "legendFormat": "current {{model}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, model) (rate(rca_latency_seconds_bucket[6h])))",
+          "legendFormat": "baseline {{model}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Latency Regression by Model",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "maintenance-intelligence",
+    "rca",
+    "cost",
+    "latency"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "RCA Cost and Latency v2",
+  "uid": "rca-observability-v2",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitoring/prometheus/rca_observability_v2_alerts.yml
+++ b/monitoring/prometheus/rca_observability_v2_alerts.yml
@@ -1,0 +1,32 @@
+groups:
+  - name: rca-observability-v2
+    rules:
+      - alert: RCASpendSpikeHourly
+        expr: sum(increase(rca_cost_usd_total[1h])) > 2 * clamp_min(sum(increase(rca_cost_usd_total[24h])) / 24, 0.01)
+        for: 15m
+        labels:
+          severity: warning
+          service: rca
+        annotations:
+          summary: RCA spend spike versus rolling baseline
+          description: RCA spend in the last hour is more than 2x the rolling 24-hour hourly baseline.
+
+      - alert: RCABudgetUtilizationHigh
+        expr: sum(increase(rca_cost_usd_total[1d])) / clamp_min(max(rca_budget_cap_usd{window="daily"}), 0.0001) > 0.9
+        for: 10m
+        labels:
+          severity: warning
+          service: rca
+        annotations:
+          summary: RCA daily budget nearly exhausted
+          description: RCA daily spend has exceeded 90% of the configured daily budget cap.
+
+      - alert: RCALatencyRegressionP95
+        expr: histogram_quantile(0.95, sum by (le, model) (rate(rca_latency_seconds_bucket[15m]))) > 1.5 * histogram_quantile(0.95, sum by (le, model) (rate(rca_latency_seconds_bucket[6h])))
+        for: 20m
+        labels:
+          severity: warning
+          service: rca
+        annotations:
+          summary: RCA latency regression detected
+          description: RCA p95 latency has regressed above 1.5x the six-hour baseline for at least one model.

--- a/tests/test_cost_metrics.py
+++ b/tests/test_cost_metrics.py
@@ -1,0 +1,19 @@
+from maintenance_intelligence.runner.config import Settings
+from maintenance_intelligence.services import rca_agent as rca_mod
+
+
+def test_estimate_cost_usd_uses_exact_or_prefix_rate(monkeypatch):
+    monkeypatch.setenv("MI_RCA_MODEL_RATES", '{"gpt-4.1": 0.5, "default": 0.1}')
+    settings = Settings()
+
+    assert rca_mod._estimate_cost_usd(2000, "gpt-4.1", settings) == 1.0
+    assert rca_mod._estimate_cost_usd(1000, "gpt-4.1-mini", settings) == 0.5
+    assert rca_mod._estimate_cost_usd(1000, "unknown-model", settings) == 0.1
+
+
+def test_estimate_cost_usd_handles_missing_tokens(monkeypatch):
+    monkeypatch.setenv("MI_RCA_MODEL_RATES", '{"gpt-4.1": 0.5}')
+    settings = Settings()
+
+    assert rca_mod._estimate_cost_usd(None, "gpt-4.1", settings) == 0.0
+    assert rca_mod._estimate_cost_usd(0, "gpt-4.1", settings) == 0.0

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -1,10 +1,16 @@
 from fastapi.testclient import TestClient
+
 from maintenance_intelligence.api.main import app
 
-def test_metrics_endpoint():
+
+def test_metrics_endpoint(monkeypatch):
+    monkeypatch.setenv("MI_RCA_BUDGET_CAPS_USD", '{"daily":12.5,"weekly":55.0}')
     c = TestClient(app)
     r = c.get("/metrics")
     assert r.status_code == 200
     body = r.text
     assert "rca_runs_total" in body
+    assert "rca_cost_usd_total" in body
+    assert "rca_latency_seconds" in body
+    assert 'rca_budget_cap_usd{window="daily"} 12.5' in body
     assert "events_ingested_total" in body

--- a/tests/test_prompt_routing.py
+++ b/tests/test_prompt_routing.py
@@ -1,11 +1,12 @@
 import json
 
-from maintenance_intelligence.api.metrics import rca_runs_by_prompt_total
+from maintenance_intelligence.api.metrics import rca_cost_usd_total, rca_latency_seconds, rca_runs_by_prompt_total
 from maintenance_intelligence.services import rca_agent as rca_mod
 
 
 def test_rca_agent_records_prompt_metadata_and_metric(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("MI_RCA_MODEL_RATES", '{"gpt-4.1": 1.0}')
 
     class FakeCons:
         def __iter__(self):
@@ -64,9 +65,17 @@ def test_rca_agent_records_prompt_metadata_and_metric(monkeypatch, tmp_path):
     monkeypatch.setattr(rca_mod, "write_run_summary", fake_write)
 
     before = rca_runs_by_prompt_total.labels(service="rca_agent", route="rca", prompt_id="rca-canary-v1", variant="canary")._value.get()
+    before_cost = rca_cost_usd_total.labels(model="gpt-4.1", prompt_id="rca-canary-v1")._value.get()
+    before_latency = rca_latency_seconds.labels(service="rca_agent", model="gpt-4.1", prompt_id="rca-canary-v1")._sum.get()
     rca_mod.rca_agent("kafka:9092")
     after = rca_runs_by_prompt_total.labels(service="rca_agent", route="rca", prompt_id="rca-canary-v1", variant="canary")._value.get()
+    after_cost = rca_cost_usd_total.labels(model="gpt-4.1", prompt_id="rca-canary-v1")._value.get()
+    after_latency = rca_latency_seconds.labels(service="rca_agent", model="gpt-4.1", prompt_id="rca-canary-v1")._sum.get()
 
     assert after == before + 1
+    assert round(after_cost - before_cost, 6) == 0.042
+    assert round(after_latency - before_latency, 6) == 0.012
     assert written["payload"]["prompt"]["prompt_id"] == "rca-canary-v1"
+    assert written["payload"]["metrics"]["estimated_cost_usd"] == 0.042
+    assert written["payload"]["model"]["estimated_cost_usd"] == 0.042
     assert written["payload"]["model"]["prompt_variant"] == "canary"


### PR DESCRIPTION
## Summary
- add RCA cost accounting and labeled latency metrics, plus budget-cap publication, so spend and latency can be tracked by model and prompt
- record estimated per-run cost into RCA summaries and increment the new Prometheus metrics directly from the RCA agent using token-based pricing config
- add a Grafana dashboard JSON, Prometheus alert rules, env knobs, and focused tests for cost estimation, metrics exposure, and prompt-aware RCA telemetry

## Validation
- /home/codespace/.python/current/bin/python -m py_compile maintenance_intelligence/api/metrics.py maintenance_intelligence/runner/config.py maintenance_intelligence/services/rca_agent.py tests/test_metrics_endpoint.py tests/test_prompt_routing.py tests/test_cost_metrics.py
- /home/codespace/.python/current/bin/python -m pytest -q tests/test_metrics_endpoint.py tests/test_prompt_routing.py tests/test_cost_metrics.py tests/test_agent_structured_mock.py