### PR TITLE
Add v0.3.0 rollout guide and operator checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,8 @@ Notes:
 - Prompt acceptance rate is derived from `prompt_feedback_total{route,prompt_id,action}` in PromQL rather than stored as a separate gauge.
 - RCA run summaries now persist `estimated_cost_usd` alongside tokens and latency for per-run auditability.
 - Dashboard and alert assets live under `monitoring/grafana/rca_observability_v2.dashboard.json` and `monitoring/prometheus/rca_observability_v2_alerts.yml`.
+
+## Rollout and Operations Docs
+
+- Rollout guide: `docs/v0.3.0-rollout-guide.md`
+- Operator checklist: `docs/v0.3.0-operator-checklist.md`

--- a/docs/v0.3.0-operator-checklist.md
+++ b/docs/v0.3.0-operator-checklist.md
@@ -1,0 +1,92 @@
+# Maintenance Intelligence v0.3.0 Operator Checklist
+
+## Purpose
+
+Use this checklist during day-to-day operation of Maintenance Intelligence v0.3.0, especially during the first few days after rollout.
+
+## Start Of Shift
+
+- Confirm API health is green.
+- Confirm RCA worker services are up.
+- Confirm Prometheus scrape for `/metrics` is healthy.
+- Check Grafana alerts for budget pressure, spend spikes, or latency regression.
+
+## Access And Tenant Checks
+
+- Verify you are using the correct API key for the intended org.
+- Confirm tenant-scoped views only show the expected org data.
+- Escalate immediately if context, signals, or outcomes appear cross-tenant.
+
+## RCA Flow Checks
+
+- Confirm new RCA recommendations contain:
+  - model version
+  - prompt ID
+  - prompt variant
+  - latency
+  - estimated cost
+- Confirm run summaries are still being written.
+
+## Dashboard Checks
+
+### Cost and budget
+
+- Review spend by model and prompt.
+- Review daily budget utilization.
+- Investigate immediately if spend spikes above expected baseline.
+
+### Latency
+
+- Review p50 and p95 latency by model and prompt.
+- Investigate if p95 latency materially regresses versus the recent baseline.
+
+### Prompt performance
+
+- Review acceptance by `prompt_id`.
+- Confirm canary traffic roughly matches the expected split.
+- Do not widen canary ratios unless acceptance and latency are stable.
+
+### Outcomes
+
+- Check per-asset acceptance for obvious drops.
+- Check TTR outliers for missing workorder lifecycle data or bad linkage.
+
+## Feedback Loop
+
+- Submit operator feedback for meaningful RCA outputs.
+- Use accept, reject, or edit rather than leaving recommendations unclassified.
+- Include enough context in rejection or edit reasons to support prompt evaluation later.
+
+## Incident Response Quick Actions
+
+### No recommendations appearing
+
+- Check API and worker health.
+- Check Kafka connectivity.
+- Check `OPENAI_API_KEY` and model budget settings.
+
+### Spend looks wrong
+
+- Check `MI_RCA_MODEL_RATES`.
+- Check prompt distribution and canary ratio.
+- Check for unexpected RCA traffic spikes.
+
+### Latency is elevated
+
+- Identify affected model and prompt.
+- Compare p95 to recent baseline.
+- Consider reducing canary traffic if the canary is the source.
+
+### Outcomes look inconsistent
+
+- Check workorder timestamp completeness.
+- Check evidence-event linkage in summaries and feedback.
+- Escalate if per-asset TTR suddenly shifts without operational cause.
+
+## End Of Day Review
+
+- Record any spend anomalies.
+- Record latency regressions.
+- Record prompt acceptance changes.
+- Record any tenant-scope anomalies or feedback submission issues.
+- Decide whether prompt ratio or budget changes need review the next day.

--- a/docs/v0.3.0-rollout-guide.md
+++ b/docs/v0.3.0-rollout-guide.md
@@ -1,0 +1,149 @@
+# Maintenance Intelligence v0.3.0 Rollout Guide
+
+## Audience
+
+This guide is for operations leads, reliability engineers, plant analysts, and maintainers rolling out Maintenance Intelligence v0.3.0 into an environment that uses RCA recommendations, feedback capture, outcomes analytics, and prompt-aware observability.
+
+## What Changed In v0.3.0
+
+### Platform capabilities
+
+- Multi-tenant RBAC is now available with API-key based access and `viewer`, `operator`, and `admin` roles.
+- Prompt catalog and A/B routing are live, including prompt-aware recommendation metadata and feedback tracking.
+- Outcomes v2 adds per-asset acceptance and refined time-to-resolution logic.
+- Cost and latency dashboards now expose model and prompt breakdowns, budget utilization, and alerting hooks.
+- The CI baseline is stabilized for continued post-release work.
+
+### Operational impact
+
+- Tenant isolation matters end to end now: API access, context assembly, signals, reports, feedback, and outcomes all depend on correct `org_id` propagation.
+- Prompt changes are observable. Prompt IDs, canary variants, and prompt-linked feedback can now be used to decide whether to expand, hold, or roll back a canary.
+- Cost controls are no longer implicit. Budget caps and prompt or model-level spend trends should be monitored after rollout.
+
+## Pre-Rollout Verification
+
+### Access and tenancy
+
+- Confirm `MI_MULTI_TENANT=true` only where tenant separation is expected.
+- Confirm `MI_AUTH_MODE=api_key` for multi-tenant environments.
+- Validate `MI_API_KEYS` entries map to the intended `org_id` and role.
+- Confirm `MI_KAFKA_TENANT_MODE` matches deployment mode:
+  - `message` for shared topics with org filtering.
+  - `namespaced` for per-org topic names.
+
+### GenAI and prompt routing
+
+- Confirm `OPENAI_API_KEY` is present where live RCA recommendations are expected.
+- Verify prompt defaults:
+  - `MI_PROMPT_DEFAULTS`
+  - `MI_PROMPT_CANARY_DEFAULTS`
+  - `MI_PROMPT_CANARY_RATIO`
+- Confirm any org-specific prompt route overrides are loaded as intended.
+
+### Cost and budget controls
+
+- Verify model pricing configuration in `MI_RCA_MODEL_RATES`.
+- Verify budget caps in `MI_RCA_BUDGET_CAPS_USD`.
+- Check that the values reflect the environment's real pricing and expected daily or weekly envelope.
+
+### Observability and alerts
+
+- Confirm Prometheus is scraping `/metrics`.
+- Import the Grafana dashboards for observability, outcomes, and cost or latency.
+- Confirm alert rules for spend spikes, budget utilization, and latency regression are loaded.
+- Enable tracing only where required:
+  - `OTEL_ENABLED=true`
+  - valid OTLP endpoint configuration.
+
+## Rollout Steps
+
+1. Upgrade the environment to the `v0.3.0` tag.
+2. Apply migrations:
+   - `alembic upgrade head`
+3. Restart API and worker processes.
+4. Confirm health endpoints and metrics are reachable.
+5. Verify tenant-scoped access with one viewer key and one operator key.
+6. Trigger or observe one RCA flow end to end.
+7. Confirm the resulting recommendation contains model and prompt metadata.
+8. Confirm one feedback submission lands successfully and increments the prompt-linked counters.
+
+## Where To Look After Rollout
+
+### Dashboards
+
+- Cost and latency dashboard:
+  - spend by `model` and `prompt_id`
+  - p50 and p95 latency by model and prompt
+  - daily and weekly budget utilization
+- Outcomes views:
+  - per-asset acceptance
+  - per-asset TTR
+  - outliers and bad actors
+- Prompt evaluation:
+  - acceptance by `prompt_id`
+  - canary versus default behavior
+
+### Alerts
+
+- Spend spike versus rolling baseline
+- Budget nearing cap
+- Latency regression by model
+
+## Feedback Loop Expectations
+
+- Operators should submit accept, reject, or edit feedback for meaningful RCA outputs.
+- Prompt-aware feedback is now part of release validation, not just a future optimization.
+- During the first monitoring window, avoid changing prompt ratios unless acceptance, cost, and latency trends are all understood.
+
+## Recommended Monitoring Window
+
+Use the first 48 to 72 hours after rollout to validate behavior before widening canaries or tightening budgets.
+
+### Watch closely
+
+- `rca_cost_usd_total` by model and prompt
+- `rca_latency_seconds` p50 and p95 by model and prompt
+- prompt acceptance derived from `prompt_feedback_total`
+- canary/default split behavior against expected ratio
+- daily and weekly budget utilization against configured caps
+
+### Adjustment guidance
+
+- Reduce canary ratio if prompt acceptance drops materially or latency regresses.
+- Revisit pricing or budget caps if spend is consistently above the intended envelope.
+- Investigate tenant mapping first if dashboards show missing or cross-tenant data anomalies.
+
+## Common Failure Modes
+
+### No live RCA output
+
+- Check `OPENAI_API_KEY`.
+- Check model routing or budget settings.
+- Confirm the RCA agent is running.
+
+### Missing tenant data
+
+- Check `org_id` propagation in incoming events and workorders.
+- Check API key mapping and Kafka tenant mode.
+
+### Empty dashboards
+
+- Confirm `/metrics` scraping.
+- Confirm RCA traffic is actually occurring.
+- Confirm Grafana is querying the intended Prometheus source.
+
+### Unexpected canary behavior
+
+- Check prompt route config and `MI_PROMPT_CANARY_RATIO`.
+- Inspect run summaries for `prompt_id`, prompt variant, and estimated cost.
+
+## Post-Release Execution Order
+
+The current recommended order for milestone `v0.3.x Post-Release Polish` is:
+
+1. Issue `#27`: Audit logs for RCA triggers and feedback
+2. Issue `#28`: IP allowlists and ingress enforcement notes
+3. Issue `#29`: Full WO lifecycle timestamps and TTR refinements
+4. Issue `#30`: Per-service metric labels and rollup dashboard panels
+
+This order prioritizes traceability and security controls before deeper outcomes refinement and observability polish.


### PR DESCRIPTION
## Summary
- add a polished v0.3.0 rollout guide for ops, reliability, and analyst audiences
- add a 1-page operator checklist for day-to-day monitoring and incident triage during the post-release window
- link both docs from the README and group post-release polish issues #27-#30 under the new `v0.3.x Post-Release Polish` milestone

## Notes
- recommended execution order for milestone work is documented in the rollout guide: #27, #28, #29, #30
- no code behavior changes are included in this PR